### PR TITLE
fix: enable golint for CI linter

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -11,6 +11,6 @@ jobs:
         uses: docker://reviewdog/action-golangci-lint:v1
         with:
           github_token: ${{ secrets.github_token }}
-          golangci_lint_flags: "--enable-all --exclude-use-default=true"
+          golangci_lint_flags: "--enable-all --exclude-use-default=false -D errcheck"
           level: error
           tool_name: golint


### PR DESCRIPTION
This way we'll get complaints about comments on structs, but disables the `errcheck` linter which will complain about things, but ["Almost all programs ignore errors on these functions and in most cases it's ok"](https://github.com/golangci/golangci-lint#command-line-options)