### PR TITLE
fix: parameter names in the request

### DIFF
--- a/twilio/rest/accounts/v1/README.md
+++ b/twilio/rest/accounts/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://accounts.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/accounts/v1/docs/DefaultApi.md
+++ b/twilio/rest/accounts/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://accounts.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
@@ -129,7 +129,7 @@ Other parameters are passed through a pointer to a CreateSecondaryAuthTokenParam
 
 ### HTTP request headers
 
-- **Content-Type**: application/x-www-form-urlencoded, 
+- **Content-Type**: Not defined
 - **Accept**: application/json, 
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
@@ -445,7 +445,7 @@ Other parameters are passed through a pointer to a UpdateAuthTokenPromotionParam
 
 ### HTTP request headers
 
-- **Content-Type**: application/x-www-form-urlencoded, 
+- **Content-Type**: Not defined
 - **Accept**: application/json, 
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)

--- a/twilio/rest/api/v2010/README.md
+++ b/twilio/rest/api/v2010/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://api.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/api/v2010/api_default.go
+++ b/twilio/rest/api/v2010/api_default.go
@@ -5799,19 +5799,19 @@ func (c *DefaultApiService) ListCall(AccountSid string, params *ListCallParams) 
 		data.Set("StartTime", fmt.Sprint((*params.StartTime).Format(time.RFC3339)))
 	}
 	if params != nil && params.StartTimeBefore != nil {
-		data.Set("StartTimeBefore", fmt.Sprint((*params.StartTimeBefore).Format(time.RFC3339)))
+		data.Set("StartTime<", fmt.Sprint((*params.StartTimeBefore).Format(time.RFC3339)))
 	}
 	if params != nil && params.StartTimeAfter != nil {
-		data.Set("StartTimeAfter", fmt.Sprint((*params.StartTimeAfter).Format(time.RFC3339)))
+		data.Set("StartTime>", fmt.Sprint((*params.StartTimeAfter).Format(time.RFC3339)))
 	}
 	if params != nil && params.EndTime != nil {
 		data.Set("EndTime", fmt.Sprint((*params.EndTime).Format(time.RFC3339)))
 	}
 	if params != nil && params.EndTimeBefore != nil {
-		data.Set("EndTimeBefore", fmt.Sprint((*params.EndTimeBefore).Format(time.RFC3339)))
+		data.Set("EndTime<", fmt.Sprint((*params.EndTimeBefore).Format(time.RFC3339)))
 	}
 	if params != nil && params.EndTimeAfter != nil {
-		data.Set("EndTimeAfter", fmt.Sprint((*params.EndTimeAfter).Format(time.RFC3339)))
+		data.Set("EndTime>", fmt.Sprint((*params.EndTimeAfter).Format(time.RFC3339)))
 	}
 	if params != nil && params.PageSize != nil {
 		data.Set("PageSize", fmt.Sprint(*params.PageSize))
@@ -5909,10 +5909,10 @@ func (c *DefaultApiService) ListCallNotification(AccountSid string, CallSid stri
 		data.Set("MessageDate", fmt.Sprint(*params.MessageDate))
 	}
 	if params != nil && params.MessageDateBefore != nil {
-		data.Set("MessageDateBefore", fmt.Sprint(*params.MessageDateBefore))
+		data.Set("MessageDate<", fmt.Sprint(*params.MessageDateBefore))
 	}
 	if params != nil && params.MessageDateAfter != nil {
-		data.Set("MessageDateAfter", fmt.Sprint(*params.MessageDateAfter))
+		data.Set("MessageDate>", fmt.Sprint(*params.MessageDateAfter))
 	}
 	if params != nil && params.PageSize != nil {
 		data.Set("PageSize", fmt.Sprint(*params.PageSize))
@@ -5965,10 +5965,10 @@ func (c *DefaultApiService) ListCallRecording(AccountSid string, CallSid string,
 		data.Set("DateCreated", fmt.Sprint(*params.DateCreated))
 	}
 	if params != nil && params.DateCreatedBefore != nil {
-		data.Set("DateCreatedBefore", fmt.Sprint(*params.DateCreatedBefore))
+		data.Set("DateCreated<", fmt.Sprint(*params.DateCreatedBefore))
 	}
 	if params != nil && params.DateCreatedAfter != nil {
-		data.Set("DateCreatedAfter", fmt.Sprint(*params.DateCreatedAfter))
+		data.Set("DateCreated>", fmt.Sprint(*params.DateCreatedAfter))
 	}
 	if params != nil && params.PageSize != nil {
 		data.Set("PageSize", fmt.Sprint(*params.PageSize))
@@ -6029,19 +6029,19 @@ func (c *DefaultApiService) ListConference(AccountSid string, params *ListConfer
 		data.Set("DateCreated", fmt.Sprint(*params.DateCreated))
 	}
 	if params != nil && params.DateCreatedBefore != nil {
-		data.Set("DateCreatedBefore", fmt.Sprint(*params.DateCreatedBefore))
+		data.Set("DateCreated<", fmt.Sprint(*params.DateCreatedBefore))
 	}
 	if params != nil && params.DateCreatedAfter != nil {
-		data.Set("DateCreatedAfter", fmt.Sprint(*params.DateCreatedAfter))
+		data.Set("DateCreated>", fmt.Sprint(*params.DateCreatedAfter))
 	}
 	if params != nil && params.DateUpdated != nil {
 		data.Set("DateUpdated", fmt.Sprint(*params.DateUpdated))
 	}
 	if params != nil && params.DateUpdatedBefore != nil {
-		data.Set("DateUpdatedBefore", fmt.Sprint(*params.DateUpdatedBefore))
+		data.Set("DateUpdated<", fmt.Sprint(*params.DateUpdatedBefore))
 	}
 	if params != nil && params.DateUpdatedAfter != nil {
-		data.Set("DateUpdatedAfter", fmt.Sprint(*params.DateUpdatedAfter))
+		data.Set("DateUpdated>", fmt.Sprint(*params.DateUpdatedAfter))
 	}
 	if params != nil && params.FriendlyName != nil {
 		data.Set("FriendlyName", *params.FriendlyName)
@@ -6100,10 +6100,10 @@ func (c *DefaultApiService) ListConferenceRecording(AccountSid string, Conferenc
 		data.Set("DateCreated", fmt.Sprint(*params.DateCreated))
 	}
 	if params != nil && params.DateCreatedBefore != nil {
-		data.Set("DateCreatedBefore", fmt.Sprint(*params.DateCreatedBefore))
+		data.Set("DateCreated<", fmt.Sprint(*params.DateCreatedBefore))
 	}
 	if params != nil && params.DateCreatedAfter != nil {
-		data.Set("DateCreatedAfter", fmt.Sprint(*params.DateCreatedAfter))
+		data.Set("DateCreated>", fmt.Sprint(*params.DateCreatedAfter))
 	}
 	if params != nil && params.PageSize != nil {
 		data.Set("PageSize", fmt.Sprint(*params.PageSize))
@@ -6590,10 +6590,10 @@ func (c *DefaultApiService) ListMedia(AccountSid string, MessageSid string, para
 		data.Set("DateCreated", fmt.Sprint((*params.DateCreated).Format(time.RFC3339)))
 	}
 	if params != nil && params.DateCreatedBefore != nil {
-		data.Set("DateCreatedBefore", fmt.Sprint((*params.DateCreatedBefore).Format(time.RFC3339)))
+		data.Set("DateCreated<", fmt.Sprint((*params.DateCreatedBefore).Format(time.RFC3339)))
 	}
 	if params != nil && params.DateCreatedAfter != nil {
-		data.Set("DateCreatedAfter", fmt.Sprint((*params.DateCreatedAfter).Format(time.RFC3339)))
+		data.Set("DateCreated>", fmt.Sprint((*params.DateCreatedAfter).Format(time.RFC3339)))
 	}
 	if params != nil && params.PageSize != nil {
 		data.Set("PageSize", fmt.Sprint(*params.PageSize))
@@ -6695,10 +6695,10 @@ func (c *DefaultApiService) ListMessage(AccountSid string, params *ListMessagePa
 		data.Set("DateSent", fmt.Sprint((*params.DateSent).Format(time.RFC3339)))
 	}
 	if params != nil && params.DateSentBefore != nil {
-		data.Set("DateSentBefore", fmt.Sprint((*params.DateSentBefore).Format(time.RFC3339)))
+		data.Set("DateSent<", fmt.Sprint((*params.DateSentBefore).Format(time.RFC3339)))
 	}
 	if params != nil && params.DateSentAfter != nil {
-		data.Set("DateSentAfter", fmt.Sprint((*params.DateSentAfter).Format(time.RFC3339)))
+		data.Set("DateSent>", fmt.Sprint((*params.DateSentAfter).Format(time.RFC3339)))
 	}
 	if params != nil && params.PageSize != nil {
 		data.Set("PageSize", fmt.Sprint(*params.PageSize))
@@ -6754,10 +6754,10 @@ func (c *DefaultApiService) ListNotification(AccountSid string, params *ListNoti
 		data.Set("MessageDate", fmt.Sprint(*params.MessageDate))
 	}
 	if params != nil && params.MessageDateBefore != nil {
-		data.Set("MessageDateBefore", fmt.Sprint(*params.MessageDateBefore))
+		data.Set("MessageDate<", fmt.Sprint(*params.MessageDateBefore))
 	}
 	if params != nil && params.MessageDateAfter != nil {
-		data.Set("MessageDateAfter", fmt.Sprint(*params.MessageDateAfter))
+		data.Set("MessageDate>", fmt.Sprint(*params.MessageDateAfter))
 	}
 	if params != nil && params.PageSize != nil {
 		data.Set("PageSize", fmt.Sprint(*params.PageSize))
@@ -6956,10 +6956,10 @@ func (c *DefaultApiService) ListRecording(AccountSid string, params *ListRecordi
 		data.Set("DateCreated", fmt.Sprint((*params.DateCreated).Format(time.RFC3339)))
 	}
 	if params != nil && params.DateCreatedBefore != nil {
-		data.Set("DateCreatedBefore", fmt.Sprint((*params.DateCreatedBefore).Format(time.RFC3339)))
+		data.Set("DateCreated<", fmt.Sprint((*params.DateCreatedBefore).Format(time.RFC3339)))
 	}
 	if params != nil && params.DateCreatedAfter != nil {
-		data.Set("DateCreatedAfter", fmt.Sprint((*params.DateCreatedAfter).Format(time.RFC3339)))
+		data.Set("DateCreated>", fmt.Sprint((*params.DateCreatedAfter).Format(time.RFC3339)))
 	}
 	if params != nil && params.CallSid != nil {
 		data.Set("CallSid", *params.CallSid)
@@ -8858,7 +8858,7 @@ func (c *DefaultApiService) UpdateIncomingPhoneNumber(AccountSid string, Sid str
 	headers := make(map[string]interface{})
 
 	if params != nil && params.AccountSid2 != nil {
-		data.Set("AccountSid2", *params.AccountSid2)
+		data.Set("AccountSid", *params.AccountSid2)
 	}
 	if params != nil && params.AddressSid != nil {
 		data.Set("AddressSid", *params.AddressSid)

--- a/twilio/rest/api/v2010/docs/DefaultApi.md
+++ b/twilio/rest/api/v2010/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://api.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/autopilot/v1/README.md
+++ b/twilio/rest/autopilot/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://autopilot.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/autopilot/v1/docs/DefaultApi.md
+++ b/twilio/rest/autopilot/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://autopilot.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/bulkexports/v1/README.md
+++ b/twilio/rest/bulkexports/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://bulkexports.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/bulkexports/v1/docs/DefaultApi.md
+++ b/twilio/rest/bulkexports/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://bulkexports.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/chat/v1/README.md
+++ b/twilio/rest/chat/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://chat.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/chat/v1/api_default.go
+++ b/twilio/rest/chat/v1/api_default.go
@@ -1603,34 +1603,34 @@ func (c *DefaultApiService) UpdateService(Sid string, params *UpdateServiceParam
 		data.Set("FriendlyName", *params.FriendlyName)
 	}
 	if params != nil && params.LimitsChannelMembers != nil {
-		data.Set("LimitsChannelMembers", fmt.Sprint(*params.LimitsChannelMembers))
+		data.Set("Limits.ChannelMembers", fmt.Sprint(*params.LimitsChannelMembers))
 	}
 	if params != nil && params.LimitsUserChannels != nil {
-		data.Set("LimitsUserChannels", fmt.Sprint(*params.LimitsUserChannels))
+		data.Set("Limits.UserChannels", fmt.Sprint(*params.LimitsUserChannels))
 	}
 	if params != nil && params.NotificationsAddedToChannelEnabled != nil {
-		data.Set("NotificationsAddedToChannelEnabled", fmt.Sprint(*params.NotificationsAddedToChannelEnabled))
+		data.Set("Notifications.AddedToChannel.Enabled", fmt.Sprint(*params.NotificationsAddedToChannelEnabled))
 	}
 	if params != nil && params.NotificationsAddedToChannelTemplate != nil {
-		data.Set("NotificationsAddedToChannelTemplate", *params.NotificationsAddedToChannelTemplate)
+		data.Set("Notifications.AddedToChannel.Template", *params.NotificationsAddedToChannelTemplate)
 	}
 	if params != nil && params.NotificationsInvitedToChannelEnabled != nil {
-		data.Set("NotificationsInvitedToChannelEnabled", fmt.Sprint(*params.NotificationsInvitedToChannelEnabled))
+		data.Set("Notifications.InvitedToChannel.Enabled", fmt.Sprint(*params.NotificationsInvitedToChannelEnabled))
 	}
 	if params != nil && params.NotificationsInvitedToChannelTemplate != nil {
-		data.Set("NotificationsInvitedToChannelTemplate", *params.NotificationsInvitedToChannelTemplate)
+		data.Set("Notifications.InvitedToChannel.Template", *params.NotificationsInvitedToChannelTemplate)
 	}
 	if params != nil && params.NotificationsNewMessageEnabled != nil {
-		data.Set("NotificationsNewMessageEnabled", fmt.Sprint(*params.NotificationsNewMessageEnabled))
+		data.Set("Notifications.NewMessage.Enabled", fmt.Sprint(*params.NotificationsNewMessageEnabled))
 	}
 	if params != nil && params.NotificationsNewMessageTemplate != nil {
-		data.Set("NotificationsNewMessageTemplate", *params.NotificationsNewMessageTemplate)
+		data.Set("Notifications.NewMessage.Template", *params.NotificationsNewMessageTemplate)
 	}
 	if params != nil && params.NotificationsRemovedFromChannelEnabled != nil {
-		data.Set("NotificationsRemovedFromChannelEnabled", fmt.Sprint(*params.NotificationsRemovedFromChannelEnabled))
+		data.Set("Notifications.RemovedFromChannel.Enabled", fmt.Sprint(*params.NotificationsRemovedFromChannelEnabled))
 	}
 	if params != nil && params.NotificationsRemovedFromChannelTemplate != nil {
-		data.Set("NotificationsRemovedFromChannelTemplate", *params.NotificationsRemovedFromChannelTemplate)
+		data.Set("Notifications.RemovedFromChannel.Template", *params.NotificationsRemovedFromChannelTemplate)
 	}
 	if params != nil && params.PostWebhookUrl != nil {
 		data.Set("PostWebhookUrl", *params.PostWebhookUrl)
@@ -1654,100 +1654,100 @@ func (c *DefaultApiService) UpdateService(Sid string, params *UpdateServiceParam
 		data.Set("WebhookMethod", *params.WebhookMethod)
 	}
 	if params != nil && params.WebhooksOnChannelAddMethod != nil {
-		data.Set("WebhooksOnChannelAddMethod", *params.WebhooksOnChannelAddMethod)
+		data.Set("Webhooks.OnChannelAdd.Method", *params.WebhooksOnChannelAddMethod)
 	}
 	if params != nil && params.WebhooksOnChannelAddUrl != nil {
-		data.Set("WebhooksOnChannelAddUrl", *params.WebhooksOnChannelAddUrl)
+		data.Set("Webhooks.OnChannelAdd.Url", *params.WebhooksOnChannelAddUrl)
 	}
 	if params != nil && params.WebhooksOnChannelAddedMethod != nil {
-		data.Set("WebhooksOnChannelAddedMethod", *params.WebhooksOnChannelAddedMethod)
+		data.Set("Webhooks.OnChannelAdded.Method", *params.WebhooksOnChannelAddedMethod)
 	}
 	if params != nil && params.WebhooksOnChannelAddedUrl != nil {
-		data.Set("WebhooksOnChannelAddedUrl", *params.WebhooksOnChannelAddedUrl)
+		data.Set("Webhooks.OnChannelAdded.Url", *params.WebhooksOnChannelAddedUrl)
 	}
 	if params != nil && params.WebhooksOnChannelDestroyMethod != nil {
-		data.Set("WebhooksOnChannelDestroyMethod", *params.WebhooksOnChannelDestroyMethod)
+		data.Set("Webhooks.OnChannelDestroy.Method", *params.WebhooksOnChannelDestroyMethod)
 	}
 	if params != nil && params.WebhooksOnChannelDestroyUrl != nil {
-		data.Set("WebhooksOnChannelDestroyUrl", *params.WebhooksOnChannelDestroyUrl)
+		data.Set("Webhooks.OnChannelDestroy.Url", *params.WebhooksOnChannelDestroyUrl)
 	}
 	if params != nil && params.WebhooksOnChannelDestroyedMethod != nil {
-		data.Set("WebhooksOnChannelDestroyedMethod", *params.WebhooksOnChannelDestroyedMethod)
+		data.Set("Webhooks.OnChannelDestroyed.Method", *params.WebhooksOnChannelDestroyedMethod)
 	}
 	if params != nil && params.WebhooksOnChannelDestroyedUrl != nil {
-		data.Set("WebhooksOnChannelDestroyedUrl", *params.WebhooksOnChannelDestroyedUrl)
+		data.Set("Webhooks.OnChannelDestroyed.Url", *params.WebhooksOnChannelDestroyedUrl)
 	}
 	if params != nil && params.WebhooksOnChannelUpdateMethod != nil {
-		data.Set("WebhooksOnChannelUpdateMethod", *params.WebhooksOnChannelUpdateMethod)
+		data.Set("Webhooks.OnChannelUpdate.Method", *params.WebhooksOnChannelUpdateMethod)
 	}
 	if params != nil && params.WebhooksOnChannelUpdateUrl != nil {
-		data.Set("WebhooksOnChannelUpdateUrl", *params.WebhooksOnChannelUpdateUrl)
+		data.Set("Webhooks.OnChannelUpdate.Url", *params.WebhooksOnChannelUpdateUrl)
 	}
 	if params != nil && params.WebhooksOnChannelUpdatedMethod != nil {
-		data.Set("WebhooksOnChannelUpdatedMethod", *params.WebhooksOnChannelUpdatedMethod)
+		data.Set("Webhooks.OnChannelUpdated.Method", *params.WebhooksOnChannelUpdatedMethod)
 	}
 	if params != nil && params.WebhooksOnChannelUpdatedUrl != nil {
-		data.Set("WebhooksOnChannelUpdatedUrl", *params.WebhooksOnChannelUpdatedUrl)
+		data.Set("Webhooks.OnChannelUpdated.Url", *params.WebhooksOnChannelUpdatedUrl)
 	}
 	if params != nil && params.WebhooksOnMemberAddMethod != nil {
-		data.Set("WebhooksOnMemberAddMethod", *params.WebhooksOnMemberAddMethod)
+		data.Set("Webhooks.OnMemberAdd.Method", *params.WebhooksOnMemberAddMethod)
 	}
 	if params != nil && params.WebhooksOnMemberAddUrl != nil {
-		data.Set("WebhooksOnMemberAddUrl", *params.WebhooksOnMemberAddUrl)
+		data.Set("Webhooks.OnMemberAdd.Url", *params.WebhooksOnMemberAddUrl)
 	}
 	if params != nil && params.WebhooksOnMemberAddedMethod != nil {
-		data.Set("WebhooksOnMemberAddedMethod", *params.WebhooksOnMemberAddedMethod)
+		data.Set("Webhooks.OnMemberAdded.Method", *params.WebhooksOnMemberAddedMethod)
 	}
 	if params != nil && params.WebhooksOnMemberAddedUrl != nil {
-		data.Set("WebhooksOnMemberAddedUrl", *params.WebhooksOnMemberAddedUrl)
+		data.Set("Webhooks.OnMemberAdded.Url", *params.WebhooksOnMemberAddedUrl)
 	}
 	if params != nil && params.WebhooksOnMemberRemoveMethod != nil {
-		data.Set("WebhooksOnMemberRemoveMethod", *params.WebhooksOnMemberRemoveMethod)
+		data.Set("Webhooks.OnMemberRemove.Method", *params.WebhooksOnMemberRemoveMethod)
 	}
 	if params != nil && params.WebhooksOnMemberRemoveUrl != nil {
-		data.Set("WebhooksOnMemberRemoveUrl", *params.WebhooksOnMemberRemoveUrl)
+		data.Set("Webhooks.OnMemberRemove.Url", *params.WebhooksOnMemberRemoveUrl)
 	}
 	if params != nil && params.WebhooksOnMemberRemovedMethod != nil {
-		data.Set("WebhooksOnMemberRemovedMethod", *params.WebhooksOnMemberRemovedMethod)
+		data.Set("Webhooks.OnMemberRemoved.Method", *params.WebhooksOnMemberRemovedMethod)
 	}
 	if params != nil && params.WebhooksOnMemberRemovedUrl != nil {
-		data.Set("WebhooksOnMemberRemovedUrl", *params.WebhooksOnMemberRemovedUrl)
+		data.Set("Webhooks.OnMemberRemoved.Url", *params.WebhooksOnMemberRemovedUrl)
 	}
 	if params != nil && params.WebhooksOnMessageRemoveMethod != nil {
-		data.Set("WebhooksOnMessageRemoveMethod", *params.WebhooksOnMessageRemoveMethod)
+		data.Set("Webhooks.OnMessageRemove.Method", *params.WebhooksOnMessageRemoveMethod)
 	}
 	if params != nil && params.WebhooksOnMessageRemoveUrl != nil {
-		data.Set("WebhooksOnMessageRemoveUrl", *params.WebhooksOnMessageRemoveUrl)
+		data.Set("Webhooks.OnMessageRemove.Url", *params.WebhooksOnMessageRemoveUrl)
 	}
 	if params != nil && params.WebhooksOnMessageRemovedMethod != nil {
-		data.Set("WebhooksOnMessageRemovedMethod", *params.WebhooksOnMessageRemovedMethod)
+		data.Set("Webhooks.OnMessageRemoved.Method", *params.WebhooksOnMessageRemovedMethod)
 	}
 	if params != nil && params.WebhooksOnMessageRemovedUrl != nil {
-		data.Set("WebhooksOnMessageRemovedUrl", *params.WebhooksOnMessageRemovedUrl)
+		data.Set("Webhooks.OnMessageRemoved.Url", *params.WebhooksOnMessageRemovedUrl)
 	}
 	if params != nil && params.WebhooksOnMessageSendMethod != nil {
-		data.Set("WebhooksOnMessageSendMethod", *params.WebhooksOnMessageSendMethod)
+		data.Set("Webhooks.OnMessageSend.Method", *params.WebhooksOnMessageSendMethod)
 	}
 	if params != nil && params.WebhooksOnMessageSendUrl != nil {
-		data.Set("WebhooksOnMessageSendUrl", *params.WebhooksOnMessageSendUrl)
+		data.Set("Webhooks.OnMessageSend.Url", *params.WebhooksOnMessageSendUrl)
 	}
 	if params != nil && params.WebhooksOnMessageSentMethod != nil {
-		data.Set("WebhooksOnMessageSentMethod", *params.WebhooksOnMessageSentMethod)
+		data.Set("Webhooks.OnMessageSent.Method", *params.WebhooksOnMessageSentMethod)
 	}
 	if params != nil && params.WebhooksOnMessageSentUrl != nil {
-		data.Set("WebhooksOnMessageSentUrl", *params.WebhooksOnMessageSentUrl)
+		data.Set("Webhooks.OnMessageSent.Url", *params.WebhooksOnMessageSentUrl)
 	}
 	if params != nil && params.WebhooksOnMessageUpdateMethod != nil {
-		data.Set("WebhooksOnMessageUpdateMethod", *params.WebhooksOnMessageUpdateMethod)
+		data.Set("Webhooks.OnMessageUpdate.Method", *params.WebhooksOnMessageUpdateMethod)
 	}
 	if params != nil && params.WebhooksOnMessageUpdateUrl != nil {
-		data.Set("WebhooksOnMessageUpdateUrl", *params.WebhooksOnMessageUpdateUrl)
+		data.Set("Webhooks.OnMessageUpdate.Url", *params.WebhooksOnMessageUpdateUrl)
 	}
 	if params != nil && params.WebhooksOnMessageUpdatedMethod != nil {
-		data.Set("WebhooksOnMessageUpdatedMethod", *params.WebhooksOnMessageUpdatedMethod)
+		data.Set("Webhooks.OnMessageUpdated.Method", *params.WebhooksOnMessageUpdatedMethod)
 	}
 	if params != nil && params.WebhooksOnMessageUpdatedUrl != nil {
-		data.Set("WebhooksOnMessageUpdatedUrl", *params.WebhooksOnMessageUpdatedUrl)
+		data.Set("Webhooks.OnMessageUpdated.Url", *params.WebhooksOnMessageUpdatedUrl)
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)

--- a/twilio/rest/chat/v1/docs/DefaultApi.md
+++ b/twilio/rest/chat/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://chat.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/chat/v2/README.md
+++ b/twilio/rest/chat/v2/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://chat.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/chat/v2/api_default.go
+++ b/twilio/rest/chat/v2/api_default.go
@@ -89,7 +89,7 @@ func (c *DefaultApiService) CreateChannel(ServiceSid string, params *CreateChann
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -141,22 +141,22 @@ func (c *DefaultApiService) CreateChannelWebhook(ServiceSid string, ChannelSid s
 	headers := make(map[string]interface{})
 
 	if params != nil && params.ConfigurationFilters != nil {
-		data.Set("ConfigurationFilters", strings.Join(*params.ConfigurationFilters, ","))
+		data.Set("Configuration.Filters", strings.Join(*params.ConfigurationFilters, ","))
 	}
 	if params != nil && params.ConfigurationFlowSid != nil {
-		data.Set("ConfigurationFlowSid", *params.ConfigurationFlowSid)
+		data.Set("Configuration.FlowSid", *params.ConfigurationFlowSid)
 	}
 	if params != nil && params.ConfigurationMethod != nil {
-		data.Set("ConfigurationMethod", *params.ConfigurationMethod)
+		data.Set("Configuration.Method", *params.ConfigurationMethod)
 	}
 	if params != nil && params.ConfigurationRetryCount != nil {
-		data.Set("ConfigurationRetryCount", fmt.Sprint(*params.ConfigurationRetryCount))
+		data.Set("Configuration.RetryCount", fmt.Sprint(*params.ConfigurationRetryCount))
 	}
 	if params != nil && params.ConfigurationTriggers != nil {
-		data.Set("ConfigurationTriggers", strings.Join(*params.ConfigurationTriggers, ","))
+		data.Set("Configuration.Triggers", strings.Join(*params.ConfigurationTriggers, ","))
 	}
 	if params != nil && params.ConfigurationUrl != nil {
-		data.Set("ConfigurationUrl", *params.ConfigurationUrl)
+		data.Set("Configuration.Url", *params.ConfigurationUrl)
 	}
 	if params != nil && params.Type != nil {
 		data.Set("Type", *params.Type)
@@ -346,7 +346,7 @@ func (c *DefaultApiService) CreateMember(ServiceSid string, ChannelSid string, p
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -422,7 +422,7 @@ func (c *DefaultApiService) CreateMessage(ServiceSid string, ChannelSid string, 
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -565,7 +565,7 @@ func (c *DefaultApiService) CreateUser(ServiceSid string, params *CreateUserPara
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -627,7 +627,7 @@ func (c *DefaultApiService) DeleteChannel(ServiceSid string, Sid string, params 
 	headers := make(map[string]interface{})
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Delete(c.baseURL+path, data, headers)
@@ -734,7 +734,7 @@ func (c *DefaultApiService) DeleteMember(ServiceSid string, ChannelSid string, S
 	headers := make(map[string]interface{})
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Delete(c.baseURL+path, data, headers)
@@ -770,7 +770,7 @@ func (c *DefaultApiService) DeleteMessage(ServiceSid string, ChannelSid string, 
 	headers := make(map[string]interface{})
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Delete(c.baseURL+path, data, headers)
@@ -1810,7 +1810,7 @@ func (c *DefaultApiService) UpdateChannel(ServiceSid string, Sid string, params 
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -1862,22 +1862,22 @@ func (c *DefaultApiService) UpdateChannelWebhook(ServiceSid string, ChannelSid s
 	headers := make(map[string]interface{})
 
 	if params != nil && params.ConfigurationFilters != nil {
-		data.Set("ConfigurationFilters", strings.Join(*params.ConfigurationFilters, ","))
+		data.Set("Configuration.Filters", strings.Join(*params.ConfigurationFilters, ","))
 	}
 	if params != nil && params.ConfigurationFlowSid != nil {
-		data.Set("ConfigurationFlowSid", *params.ConfigurationFlowSid)
+		data.Set("Configuration.FlowSid", *params.ConfigurationFlowSid)
 	}
 	if params != nil && params.ConfigurationMethod != nil {
-		data.Set("ConfigurationMethod", *params.ConfigurationMethod)
+		data.Set("Configuration.Method", *params.ConfigurationMethod)
 	}
 	if params != nil && params.ConfigurationRetryCount != nil {
-		data.Set("ConfigurationRetryCount", fmt.Sprint(*params.ConfigurationRetryCount))
+		data.Set("Configuration.RetryCount", fmt.Sprint(*params.ConfigurationRetryCount))
 	}
 	if params != nil && params.ConfigurationTriggers != nil {
-		data.Set("ConfigurationTriggers", strings.Join(*params.ConfigurationTriggers, ","))
+		data.Set("Configuration.Triggers", strings.Join(*params.ConfigurationTriggers, ","))
 	}
 	if params != nil && params.ConfigurationUrl != nil {
-		data.Set("ConfigurationUrl", *params.ConfigurationUrl)
+		data.Set("Configuration.Url", *params.ConfigurationUrl)
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -2013,7 +2013,7 @@ func (c *DefaultApiService) UpdateMember(ServiceSid string, ChannelSid string, S
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -2086,7 +2086,7 @@ func (c *DefaultApiService) UpdateMessage(ServiceSid string, ChannelSid string, 
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -2239,55 +2239,55 @@ func (c *DefaultApiService) UpdateService(Sid string, params *UpdateServiceParam
 		data.Set("FriendlyName", *params.FriendlyName)
 	}
 	if params != nil && params.LimitsChannelMembers != nil {
-		data.Set("LimitsChannelMembers", fmt.Sprint(*params.LimitsChannelMembers))
+		data.Set("Limits.ChannelMembers", fmt.Sprint(*params.LimitsChannelMembers))
 	}
 	if params != nil && params.LimitsUserChannels != nil {
-		data.Set("LimitsUserChannels", fmt.Sprint(*params.LimitsUserChannels))
+		data.Set("Limits.UserChannels", fmt.Sprint(*params.LimitsUserChannels))
 	}
 	if params != nil && params.MediaCompatibilityMessage != nil {
-		data.Set("MediaCompatibilityMessage", *params.MediaCompatibilityMessage)
+		data.Set("Media.CompatibilityMessage", *params.MediaCompatibilityMessage)
 	}
 	if params != nil && params.NotificationsAddedToChannelEnabled != nil {
-		data.Set("NotificationsAddedToChannelEnabled", fmt.Sprint(*params.NotificationsAddedToChannelEnabled))
+		data.Set("Notifications.AddedToChannel.Enabled", fmt.Sprint(*params.NotificationsAddedToChannelEnabled))
 	}
 	if params != nil && params.NotificationsAddedToChannelSound != nil {
-		data.Set("NotificationsAddedToChannelSound", *params.NotificationsAddedToChannelSound)
+		data.Set("Notifications.AddedToChannel.Sound", *params.NotificationsAddedToChannelSound)
 	}
 	if params != nil && params.NotificationsAddedToChannelTemplate != nil {
-		data.Set("NotificationsAddedToChannelTemplate", *params.NotificationsAddedToChannelTemplate)
+		data.Set("Notifications.AddedToChannel.Template", *params.NotificationsAddedToChannelTemplate)
 	}
 	if params != nil && params.NotificationsInvitedToChannelEnabled != nil {
-		data.Set("NotificationsInvitedToChannelEnabled", fmt.Sprint(*params.NotificationsInvitedToChannelEnabled))
+		data.Set("Notifications.InvitedToChannel.Enabled", fmt.Sprint(*params.NotificationsInvitedToChannelEnabled))
 	}
 	if params != nil && params.NotificationsInvitedToChannelSound != nil {
-		data.Set("NotificationsInvitedToChannelSound", *params.NotificationsInvitedToChannelSound)
+		data.Set("Notifications.InvitedToChannel.Sound", *params.NotificationsInvitedToChannelSound)
 	}
 	if params != nil && params.NotificationsInvitedToChannelTemplate != nil {
-		data.Set("NotificationsInvitedToChannelTemplate", *params.NotificationsInvitedToChannelTemplate)
+		data.Set("Notifications.InvitedToChannel.Template", *params.NotificationsInvitedToChannelTemplate)
 	}
 	if params != nil && params.NotificationsLogEnabled != nil {
-		data.Set("NotificationsLogEnabled", fmt.Sprint(*params.NotificationsLogEnabled))
+		data.Set("Notifications.LogEnabled", fmt.Sprint(*params.NotificationsLogEnabled))
 	}
 	if params != nil && params.NotificationsNewMessageBadgeCountEnabled != nil {
-		data.Set("NotificationsNewMessageBadgeCountEnabled", fmt.Sprint(*params.NotificationsNewMessageBadgeCountEnabled))
+		data.Set("Notifications.NewMessage.BadgeCountEnabled", fmt.Sprint(*params.NotificationsNewMessageBadgeCountEnabled))
 	}
 	if params != nil && params.NotificationsNewMessageEnabled != nil {
-		data.Set("NotificationsNewMessageEnabled", fmt.Sprint(*params.NotificationsNewMessageEnabled))
+		data.Set("Notifications.NewMessage.Enabled", fmt.Sprint(*params.NotificationsNewMessageEnabled))
 	}
 	if params != nil && params.NotificationsNewMessageSound != nil {
-		data.Set("NotificationsNewMessageSound", *params.NotificationsNewMessageSound)
+		data.Set("Notifications.NewMessage.Sound", *params.NotificationsNewMessageSound)
 	}
 	if params != nil && params.NotificationsNewMessageTemplate != nil {
-		data.Set("NotificationsNewMessageTemplate", *params.NotificationsNewMessageTemplate)
+		data.Set("Notifications.NewMessage.Template", *params.NotificationsNewMessageTemplate)
 	}
 	if params != nil && params.NotificationsRemovedFromChannelEnabled != nil {
-		data.Set("NotificationsRemovedFromChannelEnabled", fmt.Sprint(*params.NotificationsRemovedFromChannelEnabled))
+		data.Set("Notifications.RemovedFromChannel.Enabled", fmt.Sprint(*params.NotificationsRemovedFromChannelEnabled))
 	}
 	if params != nil && params.NotificationsRemovedFromChannelSound != nil {
-		data.Set("NotificationsRemovedFromChannelSound", *params.NotificationsRemovedFromChannelSound)
+		data.Set("Notifications.RemovedFromChannel.Sound", *params.NotificationsRemovedFromChannelSound)
 	}
 	if params != nil && params.NotificationsRemovedFromChannelTemplate != nil {
-		data.Set("NotificationsRemovedFromChannelTemplate", *params.NotificationsRemovedFromChannelTemplate)
+		data.Set("Notifications.RemovedFromChannel.Template", *params.NotificationsRemovedFromChannelTemplate)
 	}
 	if params != nil && params.PostWebhookRetryCount != nil {
 		data.Set("PostWebhookRetryCount", fmt.Sprint(*params.PostWebhookRetryCount))
@@ -2370,7 +2370,7 @@ func (c *DefaultApiService) UpdateUser(ServiceSid string, Sid string, params *Up
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)

--- a/twilio/rest/chat/v2/docs/DefaultApi.md
+++ b/twilio/rest/chat/v2/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://chat.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/conversations/v1/README.md
+++ b/twilio/rest/conversations/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://conversations.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/conversations/v1/api_default.go
+++ b/twilio/rest/conversations/v1/api_default.go
@@ -88,17 +88,17 @@ func (c *DefaultApiService) CreateConversation(params *CreateConversationParams)
 		data.Set("State", *params.State)
 	}
 	if params != nil && params.TimersClosed != nil {
-		data.Set("TimersClosed", *params.TimersClosed)
+		data.Set("Timers.Closed", *params.TimersClosed)
 	}
 	if params != nil && params.TimersInactive != nil {
-		data.Set("TimersInactive", *params.TimersInactive)
+		data.Set("Timers.Inactive", *params.TimersInactive)
 	}
 	if params != nil && params.UniqueName != nil {
 		data.Set("UniqueName", *params.UniqueName)
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -168,7 +168,7 @@ func (c *DefaultApiService) CreateConversationMessage(ConversationSid string, pa
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -235,20 +235,20 @@ func (c *DefaultApiService) CreateConversationParticipant(ConversationSid string
 		data.Set("Identity", *params.Identity)
 	}
 	if params != nil && params.MessagingBindingAddress != nil {
-		data.Set("MessagingBindingAddress", *params.MessagingBindingAddress)
+		data.Set("MessagingBinding.Address", *params.MessagingBindingAddress)
 	}
 	if params != nil && params.MessagingBindingProjectedAddress != nil {
-		data.Set("MessagingBindingProjectedAddress", *params.MessagingBindingProjectedAddress)
+		data.Set("MessagingBinding.ProjectedAddress", *params.MessagingBindingProjectedAddress)
 	}
 	if params != nil && params.MessagingBindingProxyAddress != nil {
-		data.Set("MessagingBindingProxyAddress", *params.MessagingBindingProxyAddress)
+		data.Set("MessagingBinding.ProxyAddress", *params.MessagingBindingProxyAddress)
 	}
 	if params != nil && params.RoleSid != nil {
 		data.Set("RoleSid", *params.RoleSid)
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -299,22 +299,22 @@ func (c *DefaultApiService) CreateConversationScopedWebhook(ConversationSid stri
 	headers := make(map[string]interface{})
 
 	if params != nil && params.ConfigurationFilters != nil {
-		data.Set("ConfigurationFilters", strings.Join(*params.ConfigurationFilters, ","))
+		data.Set("Configuration.Filters", strings.Join(*params.ConfigurationFilters, ","))
 	}
 	if params != nil && params.ConfigurationFlowSid != nil {
-		data.Set("ConfigurationFlowSid", *params.ConfigurationFlowSid)
+		data.Set("Configuration.FlowSid", *params.ConfigurationFlowSid)
 	}
 	if params != nil && params.ConfigurationMethod != nil {
-		data.Set("ConfigurationMethod", *params.ConfigurationMethod)
+		data.Set("Configuration.Method", *params.ConfigurationMethod)
 	}
 	if params != nil && params.ConfigurationReplayAfter != nil {
-		data.Set("ConfigurationReplayAfter", fmt.Sprint(*params.ConfigurationReplayAfter))
+		data.Set("Configuration.ReplayAfter", fmt.Sprint(*params.ConfigurationReplayAfter))
 	}
 	if params != nil && params.ConfigurationTriggers != nil {
-		data.Set("ConfigurationTriggers", strings.Join(*params.ConfigurationTriggers, ","))
+		data.Set("Configuration.Triggers", strings.Join(*params.ConfigurationTriggers, ","))
 	}
 	if params != nil && params.ConfigurationUrl != nil {
-		data.Set("ConfigurationUrl", *params.ConfigurationUrl)
+		data.Set("Configuration.Url", *params.ConfigurationUrl)
 	}
 	if params != nil && params.Target != nil {
 		data.Set("Target", *params.Target)
@@ -543,17 +543,17 @@ func (c *DefaultApiService) CreateServiceConversation(ChatServiceSid string, par
 		data.Set("State", *params.State)
 	}
 	if params != nil && params.TimersClosed != nil {
-		data.Set("TimersClosed", *params.TimersClosed)
+		data.Set("Timers.Closed", *params.TimersClosed)
 	}
 	if params != nil && params.TimersInactive != nil {
-		data.Set("TimersInactive", *params.TimersInactive)
+		data.Set("Timers.Inactive", *params.TimersInactive)
 	}
 	if params != nil && params.UniqueName != nil {
 		data.Set("UniqueName", *params.UniqueName)
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -625,7 +625,7 @@ func (c *DefaultApiService) CreateServiceConversationMessage(ChatServiceSid stri
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -694,20 +694,20 @@ func (c *DefaultApiService) CreateServiceConversationParticipant(ChatServiceSid 
 		data.Set("Identity", *params.Identity)
 	}
 	if params != nil && params.MessagingBindingAddress != nil {
-		data.Set("MessagingBindingAddress", *params.MessagingBindingAddress)
+		data.Set("MessagingBinding.Address", *params.MessagingBindingAddress)
 	}
 	if params != nil && params.MessagingBindingProjectedAddress != nil {
-		data.Set("MessagingBindingProjectedAddress", *params.MessagingBindingProjectedAddress)
+		data.Set("MessagingBinding.ProjectedAddress", *params.MessagingBindingProjectedAddress)
 	}
 	if params != nil && params.MessagingBindingProxyAddress != nil {
-		data.Set("MessagingBindingProxyAddress", *params.MessagingBindingProxyAddress)
+		data.Set("MessagingBinding.ProxyAddress", *params.MessagingBindingProxyAddress)
 	}
 	if params != nil && params.RoleSid != nil {
 		data.Set("RoleSid", *params.RoleSid)
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -760,22 +760,22 @@ func (c *DefaultApiService) CreateServiceConversationScopedWebhook(ChatServiceSi
 	headers := make(map[string]interface{})
 
 	if params != nil && params.ConfigurationFilters != nil {
-		data.Set("ConfigurationFilters", strings.Join(*params.ConfigurationFilters, ","))
+		data.Set("Configuration.Filters", strings.Join(*params.ConfigurationFilters, ","))
 	}
 	if params != nil && params.ConfigurationFlowSid != nil {
-		data.Set("ConfigurationFlowSid", *params.ConfigurationFlowSid)
+		data.Set("Configuration.FlowSid", *params.ConfigurationFlowSid)
 	}
 	if params != nil && params.ConfigurationMethod != nil {
-		data.Set("ConfigurationMethod", *params.ConfigurationMethod)
+		data.Set("Configuration.Method", *params.ConfigurationMethod)
 	}
 	if params != nil && params.ConfigurationReplayAfter != nil {
-		data.Set("ConfigurationReplayAfter", fmt.Sprint(*params.ConfigurationReplayAfter))
+		data.Set("Configuration.ReplayAfter", fmt.Sprint(*params.ConfigurationReplayAfter))
 	}
 	if params != nil && params.ConfigurationTriggers != nil {
-		data.Set("ConfigurationTriggers", strings.Join(*params.ConfigurationTriggers, ","))
+		data.Set("Configuration.Triggers", strings.Join(*params.ConfigurationTriggers, ","))
 	}
 	if params != nil && params.ConfigurationUrl != nil {
-		data.Set("ConfigurationUrl", *params.ConfigurationUrl)
+		data.Set("Configuration.Url", *params.ConfigurationUrl)
 	}
 	if params != nil && params.Target != nil {
 		data.Set("Target", *params.Target)
@@ -887,7 +887,7 @@ func (c *DefaultApiService) CreateServiceUser(ChatServiceSid string, params *Cre
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -945,7 +945,7 @@ func (c *DefaultApiService) CreateUser(params *CreateUserParams) (*Conversations
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -983,7 +983,7 @@ func (c *DefaultApiService) DeleteConversation(Sid string, params *DeleteConvers
 	headers := make(map[string]interface{})
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Delete(c.baseURL+path, data, headers)
@@ -1018,7 +1018,7 @@ func (c *DefaultApiService) DeleteConversationMessage(ConversationSid string, Si
 	headers := make(map[string]interface{})
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Delete(c.baseURL+path, data, headers)
@@ -1053,7 +1053,7 @@ func (c *DefaultApiService) DeleteConversationParticipant(ConversationSid string
 	headers := make(map[string]interface{})
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Delete(c.baseURL+path, data, headers)
@@ -1202,7 +1202,7 @@ func (c *DefaultApiService) DeleteServiceConversation(ChatServiceSid string, Sid
 	headers := make(map[string]interface{})
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Delete(c.baseURL+path, data, headers)
@@ -1239,7 +1239,7 @@ func (c *DefaultApiService) DeleteServiceConversationMessage(ChatServiceSid stri
 	headers := make(map[string]interface{})
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Delete(c.baseURL+path, data, headers)
@@ -1276,7 +1276,7 @@ func (c *DefaultApiService) DeleteServiceConversationParticipant(ChatServiceSid 
 	headers := make(map[string]interface{})
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Delete(c.baseURL+path, data, headers)
@@ -1361,7 +1361,7 @@ func (c *DefaultApiService) DeleteServiceUser(ChatServiceSid string, Sid string,
 	headers := make(map[string]interface{})
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Delete(c.baseURL+path, data, headers)
@@ -1394,7 +1394,7 @@ func (c *DefaultApiService) DeleteUser(Sid string, params *DeleteUserParams) err
 	headers := make(map[string]interface{})
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Delete(c.baseURL+path, data, headers)
@@ -2866,17 +2866,17 @@ func (c *DefaultApiService) UpdateConversation(Sid string, params *UpdateConvers
 		data.Set("State", *params.State)
 	}
 	if params != nil && params.TimersClosed != nil {
-		data.Set("TimersClosed", *params.TimersClosed)
+		data.Set("Timers.Closed", *params.TimersClosed)
 	}
 	if params != nil && params.TimersInactive != nil {
-		data.Set("TimersInactive", *params.TimersInactive)
+		data.Set("Timers.Inactive", *params.TimersInactive)
 	}
 	if params != nil && params.UniqueName != nil {
 		data.Set("UniqueName", *params.UniqueName)
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -2943,7 +2943,7 @@ func (c *DefaultApiService) UpdateConversationMessage(ConversationSid string, Si
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -3020,17 +3020,17 @@ func (c *DefaultApiService) UpdateConversationParticipant(ConversationSid string
 		data.Set("LastReadTimestamp", *params.LastReadTimestamp)
 	}
 	if params != nil && params.MessagingBindingProjectedAddress != nil {
-		data.Set("MessagingBindingProjectedAddress", *params.MessagingBindingProjectedAddress)
+		data.Set("MessagingBinding.ProjectedAddress", *params.MessagingBindingProjectedAddress)
 	}
 	if params != nil && params.MessagingBindingProxyAddress != nil {
-		data.Set("MessagingBindingProxyAddress", *params.MessagingBindingProxyAddress)
+		data.Set("MessagingBinding.ProxyAddress", *params.MessagingBindingProxyAddress)
 	}
 	if params != nil && params.RoleSid != nil {
 		data.Set("RoleSid", *params.RoleSid)
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -3079,19 +3079,19 @@ func (c *DefaultApiService) UpdateConversationScopedWebhook(ConversationSid stri
 	headers := make(map[string]interface{})
 
 	if params != nil && params.ConfigurationFilters != nil {
-		data.Set("ConfigurationFilters", strings.Join(*params.ConfigurationFilters, ","))
+		data.Set("Configuration.Filters", strings.Join(*params.ConfigurationFilters, ","))
 	}
 	if params != nil && params.ConfigurationFlowSid != nil {
-		data.Set("ConfigurationFlowSid", *params.ConfigurationFlowSid)
+		data.Set("Configuration.FlowSid", *params.ConfigurationFlowSid)
 	}
 	if params != nil && params.ConfigurationMethod != nil {
-		data.Set("ConfigurationMethod", *params.ConfigurationMethod)
+		data.Set("Configuration.Method", *params.ConfigurationMethod)
 	}
 	if params != nil && params.ConfigurationTriggers != nil {
-		data.Set("ConfigurationTriggers", strings.Join(*params.ConfigurationTriggers, ","))
+		data.Set("Configuration.Triggers", strings.Join(*params.ConfigurationTriggers, ","))
 	}
 	if params != nil && params.ConfigurationUrl != nil {
-		data.Set("ConfigurationUrl", *params.ConfigurationUrl)
+		data.Set("Configuration.Url", *params.ConfigurationUrl)
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -3330,17 +3330,17 @@ func (c *DefaultApiService) UpdateServiceConversation(ChatServiceSid string, Sid
 		data.Set("State", *params.State)
 	}
 	if params != nil && params.TimersClosed != nil {
-		data.Set("TimersClosed", *params.TimersClosed)
+		data.Set("Timers.Closed", *params.TimersClosed)
 	}
 	if params != nil && params.TimersInactive != nil {
-		data.Set("TimersInactive", *params.TimersInactive)
+		data.Set("Timers.Inactive", *params.TimersInactive)
 	}
 	if params != nil && params.UniqueName != nil {
 		data.Set("UniqueName", *params.UniqueName)
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -3409,7 +3409,7 @@ func (c *DefaultApiService) UpdateServiceConversationMessage(ChatServiceSid stri
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -3488,17 +3488,17 @@ func (c *DefaultApiService) UpdateServiceConversationParticipant(ChatServiceSid 
 		data.Set("LastReadTimestamp", *params.LastReadTimestamp)
 	}
 	if params != nil && params.MessagingBindingProjectedAddress != nil {
-		data.Set("MessagingBindingProjectedAddress", *params.MessagingBindingProjectedAddress)
+		data.Set("MessagingBinding.ProjectedAddress", *params.MessagingBindingProjectedAddress)
 	}
 	if params != nil && params.MessagingBindingProxyAddress != nil {
-		data.Set("MessagingBindingProxyAddress", *params.MessagingBindingProxyAddress)
+		data.Set("MessagingBinding.ProxyAddress", *params.MessagingBindingProxyAddress)
 	}
 	if params != nil && params.RoleSid != nil {
 		data.Set("RoleSid", *params.RoleSid)
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -3549,19 +3549,19 @@ func (c *DefaultApiService) UpdateServiceConversationScopedWebhook(ChatServiceSi
 	headers := make(map[string]interface{})
 
 	if params != nil && params.ConfigurationFilters != nil {
-		data.Set("ConfigurationFilters", strings.Join(*params.ConfigurationFilters, ","))
+		data.Set("Configuration.Filters", strings.Join(*params.ConfigurationFilters, ","))
 	}
 	if params != nil && params.ConfigurationFlowSid != nil {
-		data.Set("ConfigurationFlowSid", *params.ConfigurationFlowSid)
+		data.Set("Configuration.FlowSid", *params.ConfigurationFlowSid)
 	}
 	if params != nil && params.ConfigurationMethod != nil {
-		data.Set("ConfigurationMethod", *params.ConfigurationMethod)
+		data.Set("Configuration.Method", *params.ConfigurationMethod)
 	}
 	if params != nil && params.ConfigurationTriggers != nil {
-		data.Set("ConfigurationTriggers", strings.Join(*params.ConfigurationTriggers, ","))
+		data.Set("Configuration.Triggers", strings.Join(*params.ConfigurationTriggers, ","))
 	}
 	if params != nil && params.ConfigurationUrl != nil {
-		data.Set("ConfigurationUrl", *params.ConfigurationUrl)
+		data.Set("Configuration.Url", *params.ConfigurationUrl)
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -3620,37 +3620,37 @@ func (c *DefaultApiService) UpdateServiceNotification(ChatServiceSid string, par
 	headers := make(map[string]interface{})
 
 	if params != nil && params.AddedToConversationEnabled != nil {
-		data.Set("AddedToConversationEnabled", fmt.Sprint(*params.AddedToConversationEnabled))
+		data.Set("AddedToConversation.Enabled", fmt.Sprint(*params.AddedToConversationEnabled))
 	}
 	if params != nil && params.AddedToConversationSound != nil {
-		data.Set("AddedToConversationSound", *params.AddedToConversationSound)
+		data.Set("AddedToConversation.Sound", *params.AddedToConversationSound)
 	}
 	if params != nil && params.AddedToConversationTemplate != nil {
-		data.Set("AddedToConversationTemplate", *params.AddedToConversationTemplate)
+		data.Set("AddedToConversation.Template", *params.AddedToConversationTemplate)
 	}
 	if params != nil && params.LogEnabled != nil {
 		data.Set("LogEnabled", fmt.Sprint(*params.LogEnabled))
 	}
 	if params != nil && params.NewMessageBadgeCountEnabled != nil {
-		data.Set("NewMessageBadgeCountEnabled", fmt.Sprint(*params.NewMessageBadgeCountEnabled))
+		data.Set("NewMessage.BadgeCountEnabled", fmt.Sprint(*params.NewMessageBadgeCountEnabled))
 	}
 	if params != nil && params.NewMessageEnabled != nil {
-		data.Set("NewMessageEnabled", fmt.Sprint(*params.NewMessageEnabled))
+		data.Set("NewMessage.Enabled", fmt.Sprint(*params.NewMessageEnabled))
 	}
 	if params != nil && params.NewMessageSound != nil {
-		data.Set("NewMessageSound", *params.NewMessageSound)
+		data.Set("NewMessage.Sound", *params.NewMessageSound)
 	}
 	if params != nil && params.NewMessageTemplate != nil {
-		data.Set("NewMessageTemplate", *params.NewMessageTemplate)
+		data.Set("NewMessage.Template", *params.NewMessageTemplate)
 	}
 	if params != nil && params.RemovedFromConversationEnabled != nil {
-		data.Set("RemovedFromConversationEnabled", fmt.Sprint(*params.RemovedFromConversationEnabled))
+		data.Set("RemovedFromConversation.Enabled", fmt.Sprint(*params.RemovedFromConversationEnabled))
 	}
 	if params != nil && params.RemovedFromConversationSound != nil {
-		data.Set("RemovedFromConversationSound", *params.RemovedFromConversationSound)
+		data.Set("RemovedFromConversation.Sound", *params.RemovedFromConversationSound)
 	}
 	if params != nil && params.RemovedFromConversationTemplate != nil {
-		data.Set("RemovedFromConversationTemplate", *params.RemovedFromConversationTemplate)
+		data.Set("RemovedFromConversation.Template", *params.RemovedFromConversationTemplate)
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -3748,7 +3748,7 @@ func (c *DefaultApiService) UpdateServiceUser(ChatServiceSid string, Sid string,
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -3803,7 +3803,7 @@ func (c *DefaultApiService) UpdateUser(Sid string, params *UpdateUserParams) (*C
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)

--- a/twilio/rest/conversations/v1/docs/DefaultApi.md
+++ b/twilio/rest/conversations/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://conversations.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/events/v1/README.md
+++ b/twilio/rest/events/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://events.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/events/v1/docs/DefaultApi.md
+++ b/twilio/rest/events/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://events.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
@@ -103,7 +103,7 @@ Name | Type | Description
 
 ### HTTP request headers
 
-- **Content-Type**: application/x-www-form-urlencoded, 
+- **Content-Type**: Not defined
 - **Accept**: application/json, 
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)

--- a/twilio/rest/fax/v1/README.md
+++ b/twilio/rest/fax/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://fax.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/fax/v1/docs/DefaultApi.md
+++ b/twilio/rest/fax/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://fax.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/flex/v1/README.md
+++ b/twilio/rest/flex/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://flex-api.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/flex/v1/api_default.go
+++ b/twilio/rest/flex/v1/api_default.go
@@ -178,31 +178,31 @@ func (c *DefaultApiService) CreateFlexFlow(params *CreateFlexFlowParams) (*FlexV
 		data.Set("FriendlyName", *params.FriendlyName)
 	}
 	if params != nil && params.IntegrationChannel != nil {
-		data.Set("IntegrationChannel", *params.IntegrationChannel)
+		data.Set("Integration.Channel", *params.IntegrationChannel)
 	}
 	if params != nil && params.IntegrationCreationOnMessage != nil {
-		data.Set("IntegrationCreationOnMessage", fmt.Sprint(*params.IntegrationCreationOnMessage))
+		data.Set("Integration.CreationOnMessage", fmt.Sprint(*params.IntegrationCreationOnMessage))
 	}
 	if params != nil && params.IntegrationFlowSid != nil {
-		data.Set("IntegrationFlowSid", *params.IntegrationFlowSid)
+		data.Set("Integration.FlowSid", *params.IntegrationFlowSid)
 	}
 	if params != nil && params.IntegrationPriority != nil {
-		data.Set("IntegrationPriority", fmt.Sprint(*params.IntegrationPriority))
+		data.Set("Integration.Priority", fmt.Sprint(*params.IntegrationPriority))
 	}
 	if params != nil && params.IntegrationRetryCount != nil {
-		data.Set("IntegrationRetryCount", fmt.Sprint(*params.IntegrationRetryCount))
+		data.Set("Integration.RetryCount", fmt.Sprint(*params.IntegrationRetryCount))
 	}
 	if params != nil && params.IntegrationTimeout != nil {
-		data.Set("IntegrationTimeout", fmt.Sprint(*params.IntegrationTimeout))
+		data.Set("Integration.Timeout", fmt.Sprint(*params.IntegrationTimeout))
 	}
 	if params != nil && params.IntegrationUrl != nil {
-		data.Set("IntegrationUrl", *params.IntegrationUrl)
+		data.Set("Integration.Url", *params.IntegrationUrl)
 	}
 	if params != nil && params.IntegrationWorkflowSid != nil {
-		data.Set("IntegrationWorkflowSid", *params.IntegrationWorkflowSid)
+		data.Set("Integration.WorkflowSid", *params.IntegrationWorkflowSid)
 	}
 	if params != nil && params.IntegrationWorkspaceSid != nil {
-		data.Set("IntegrationWorkspaceSid", *params.IntegrationWorkspaceSid)
+		data.Set("Integration.WorkspaceSid", *params.IntegrationWorkspaceSid)
 	}
 	if params != nil && params.IntegrationType != nil {
 		data.Set("IntegrationType", *params.IntegrationType)
@@ -675,31 +675,31 @@ func (c *DefaultApiService) UpdateFlexFlow(Sid string, params *UpdateFlexFlowPar
 		data.Set("FriendlyName", *params.FriendlyName)
 	}
 	if params != nil && params.IntegrationChannel != nil {
-		data.Set("IntegrationChannel", *params.IntegrationChannel)
+		data.Set("Integration.Channel", *params.IntegrationChannel)
 	}
 	if params != nil && params.IntegrationCreationOnMessage != nil {
-		data.Set("IntegrationCreationOnMessage", fmt.Sprint(*params.IntegrationCreationOnMessage))
+		data.Set("Integration.CreationOnMessage", fmt.Sprint(*params.IntegrationCreationOnMessage))
 	}
 	if params != nil && params.IntegrationFlowSid != nil {
-		data.Set("IntegrationFlowSid", *params.IntegrationFlowSid)
+		data.Set("Integration.FlowSid", *params.IntegrationFlowSid)
 	}
 	if params != nil && params.IntegrationPriority != nil {
-		data.Set("IntegrationPriority", fmt.Sprint(*params.IntegrationPriority))
+		data.Set("Integration.Priority", fmt.Sprint(*params.IntegrationPriority))
 	}
 	if params != nil && params.IntegrationRetryCount != nil {
-		data.Set("IntegrationRetryCount", fmt.Sprint(*params.IntegrationRetryCount))
+		data.Set("Integration.RetryCount", fmt.Sprint(*params.IntegrationRetryCount))
 	}
 	if params != nil && params.IntegrationTimeout != nil {
-		data.Set("IntegrationTimeout", fmt.Sprint(*params.IntegrationTimeout))
+		data.Set("Integration.Timeout", fmt.Sprint(*params.IntegrationTimeout))
 	}
 	if params != nil && params.IntegrationUrl != nil {
-		data.Set("IntegrationUrl", *params.IntegrationUrl)
+		data.Set("Integration.Url", *params.IntegrationUrl)
 	}
 	if params != nil && params.IntegrationWorkflowSid != nil {
-		data.Set("IntegrationWorkflowSid", *params.IntegrationWorkflowSid)
+		data.Set("Integration.WorkflowSid", *params.IntegrationWorkflowSid)
 	}
 	if params != nil && params.IntegrationWorkspaceSid != nil {
-		data.Set("IntegrationWorkspaceSid", *params.IntegrationWorkspaceSid)
+		data.Set("Integration.WorkspaceSid", *params.IntegrationWorkspaceSid)
 	}
 	if params != nil && params.IntegrationType != nil {
 		data.Set("IntegrationType", *params.IntegrationType)

--- a/twilio/rest/flex/v1/docs/DefaultApi.md
+++ b/twilio/rest/flex/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://flex-api.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
@@ -578,7 +578,7 @@ Other parameters are passed through a pointer to a UpdateConfigurationParams str
 
 ### HTTP request headers
 
-- **Content-Type**: application/x-www-form-urlencoded, 
+- **Content-Type**: Not defined
 - **Accept**: application/json, 
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)

--- a/twilio/rest/insights/v1/README.md
+++ b/twilio/rest/insights/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://insights.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/insights/v1/docs/DefaultApi.md
+++ b/twilio/rest/insights/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://insights.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/ip_messaging/v1/README.md
+++ b/twilio/rest/ip_messaging/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://ip-messaging.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/ip_messaging/v1/api_default.go
+++ b/twilio/rest/ip_messaging/v1/api_default.go
@@ -1602,34 +1602,34 @@ func (c *DefaultApiService) UpdateService(Sid string, params *UpdateServiceParam
 		data.Set("FriendlyName", *params.FriendlyName)
 	}
 	if params != nil && params.LimitsChannelMembers != nil {
-		data.Set("LimitsChannelMembers", fmt.Sprint(*params.LimitsChannelMembers))
+		data.Set("Limits.ChannelMembers", fmt.Sprint(*params.LimitsChannelMembers))
 	}
 	if params != nil && params.LimitsUserChannels != nil {
-		data.Set("LimitsUserChannels", fmt.Sprint(*params.LimitsUserChannels))
+		data.Set("Limits.UserChannels", fmt.Sprint(*params.LimitsUserChannels))
 	}
 	if params != nil && params.NotificationsAddedToChannelEnabled != nil {
-		data.Set("NotificationsAddedToChannelEnabled", fmt.Sprint(*params.NotificationsAddedToChannelEnabled))
+		data.Set("Notifications.AddedToChannel.Enabled", fmt.Sprint(*params.NotificationsAddedToChannelEnabled))
 	}
 	if params != nil && params.NotificationsAddedToChannelTemplate != nil {
-		data.Set("NotificationsAddedToChannelTemplate", *params.NotificationsAddedToChannelTemplate)
+		data.Set("Notifications.AddedToChannel.Template", *params.NotificationsAddedToChannelTemplate)
 	}
 	if params != nil && params.NotificationsInvitedToChannelEnabled != nil {
-		data.Set("NotificationsInvitedToChannelEnabled", fmt.Sprint(*params.NotificationsInvitedToChannelEnabled))
+		data.Set("Notifications.InvitedToChannel.Enabled", fmt.Sprint(*params.NotificationsInvitedToChannelEnabled))
 	}
 	if params != nil && params.NotificationsInvitedToChannelTemplate != nil {
-		data.Set("NotificationsInvitedToChannelTemplate", *params.NotificationsInvitedToChannelTemplate)
+		data.Set("Notifications.InvitedToChannel.Template", *params.NotificationsInvitedToChannelTemplate)
 	}
 	if params != nil && params.NotificationsNewMessageEnabled != nil {
-		data.Set("NotificationsNewMessageEnabled", fmt.Sprint(*params.NotificationsNewMessageEnabled))
+		data.Set("Notifications.NewMessage.Enabled", fmt.Sprint(*params.NotificationsNewMessageEnabled))
 	}
 	if params != nil && params.NotificationsNewMessageTemplate != nil {
-		data.Set("NotificationsNewMessageTemplate", *params.NotificationsNewMessageTemplate)
+		data.Set("Notifications.NewMessage.Template", *params.NotificationsNewMessageTemplate)
 	}
 	if params != nil && params.NotificationsRemovedFromChannelEnabled != nil {
-		data.Set("NotificationsRemovedFromChannelEnabled", fmt.Sprint(*params.NotificationsRemovedFromChannelEnabled))
+		data.Set("Notifications.RemovedFromChannel.Enabled", fmt.Sprint(*params.NotificationsRemovedFromChannelEnabled))
 	}
 	if params != nil && params.NotificationsRemovedFromChannelTemplate != nil {
-		data.Set("NotificationsRemovedFromChannelTemplate", *params.NotificationsRemovedFromChannelTemplate)
+		data.Set("Notifications.RemovedFromChannel.Template", *params.NotificationsRemovedFromChannelTemplate)
 	}
 	if params != nil && params.PostWebhookUrl != nil {
 		data.Set("PostWebhookUrl", *params.PostWebhookUrl)
@@ -1653,100 +1653,100 @@ func (c *DefaultApiService) UpdateService(Sid string, params *UpdateServiceParam
 		data.Set("WebhookMethod", *params.WebhookMethod)
 	}
 	if params != nil && params.WebhooksOnChannelAddMethod != nil {
-		data.Set("WebhooksOnChannelAddMethod", *params.WebhooksOnChannelAddMethod)
+		data.Set("Webhooks.OnChannelAdd.Method", *params.WebhooksOnChannelAddMethod)
 	}
 	if params != nil && params.WebhooksOnChannelAddUrl != nil {
-		data.Set("WebhooksOnChannelAddUrl", *params.WebhooksOnChannelAddUrl)
+		data.Set("Webhooks.OnChannelAdd.Url", *params.WebhooksOnChannelAddUrl)
 	}
 	if params != nil && params.WebhooksOnChannelAddedMethod != nil {
-		data.Set("WebhooksOnChannelAddedMethod", *params.WebhooksOnChannelAddedMethod)
+		data.Set("Webhooks.OnChannelAdded.Method", *params.WebhooksOnChannelAddedMethod)
 	}
 	if params != nil && params.WebhooksOnChannelAddedUrl != nil {
-		data.Set("WebhooksOnChannelAddedUrl", *params.WebhooksOnChannelAddedUrl)
+		data.Set("Webhooks.OnChannelAdded.Url", *params.WebhooksOnChannelAddedUrl)
 	}
 	if params != nil && params.WebhooksOnChannelDestroyMethod != nil {
-		data.Set("WebhooksOnChannelDestroyMethod", *params.WebhooksOnChannelDestroyMethod)
+		data.Set("Webhooks.OnChannelDestroy.Method", *params.WebhooksOnChannelDestroyMethod)
 	}
 	if params != nil && params.WebhooksOnChannelDestroyUrl != nil {
-		data.Set("WebhooksOnChannelDestroyUrl", *params.WebhooksOnChannelDestroyUrl)
+		data.Set("Webhooks.OnChannelDestroy.Url", *params.WebhooksOnChannelDestroyUrl)
 	}
 	if params != nil && params.WebhooksOnChannelDestroyedMethod != nil {
-		data.Set("WebhooksOnChannelDestroyedMethod", *params.WebhooksOnChannelDestroyedMethod)
+		data.Set("Webhooks.OnChannelDestroyed.Method", *params.WebhooksOnChannelDestroyedMethod)
 	}
 	if params != nil && params.WebhooksOnChannelDestroyedUrl != nil {
-		data.Set("WebhooksOnChannelDestroyedUrl", *params.WebhooksOnChannelDestroyedUrl)
+		data.Set("Webhooks.OnChannelDestroyed.Url", *params.WebhooksOnChannelDestroyedUrl)
 	}
 	if params != nil && params.WebhooksOnChannelUpdateMethod != nil {
-		data.Set("WebhooksOnChannelUpdateMethod", *params.WebhooksOnChannelUpdateMethod)
+		data.Set("Webhooks.OnChannelUpdate.Method", *params.WebhooksOnChannelUpdateMethod)
 	}
 	if params != nil && params.WebhooksOnChannelUpdateUrl != nil {
-		data.Set("WebhooksOnChannelUpdateUrl", *params.WebhooksOnChannelUpdateUrl)
+		data.Set("Webhooks.OnChannelUpdate.Url", *params.WebhooksOnChannelUpdateUrl)
 	}
 	if params != nil && params.WebhooksOnChannelUpdatedMethod != nil {
-		data.Set("WebhooksOnChannelUpdatedMethod", *params.WebhooksOnChannelUpdatedMethod)
+		data.Set("Webhooks.OnChannelUpdated.Method", *params.WebhooksOnChannelUpdatedMethod)
 	}
 	if params != nil && params.WebhooksOnChannelUpdatedUrl != nil {
-		data.Set("WebhooksOnChannelUpdatedUrl", *params.WebhooksOnChannelUpdatedUrl)
+		data.Set("Webhooks.OnChannelUpdated.Url", *params.WebhooksOnChannelUpdatedUrl)
 	}
 	if params != nil && params.WebhooksOnMemberAddMethod != nil {
-		data.Set("WebhooksOnMemberAddMethod", *params.WebhooksOnMemberAddMethod)
+		data.Set("Webhooks.OnMemberAdd.Method", *params.WebhooksOnMemberAddMethod)
 	}
 	if params != nil && params.WebhooksOnMemberAddUrl != nil {
-		data.Set("WebhooksOnMemberAddUrl", *params.WebhooksOnMemberAddUrl)
+		data.Set("Webhooks.OnMemberAdd.Url", *params.WebhooksOnMemberAddUrl)
 	}
 	if params != nil && params.WebhooksOnMemberAddedMethod != nil {
-		data.Set("WebhooksOnMemberAddedMethod", *params.WebhooksOnMemberAddedMethod)
+		data.Set("Webhooks.OnMemberAdded.Method", *params.WebhooksOnMemberAddedMethod)
 	}
 	if params != nil && params.WebhooksOnMemberAddedUrl != nil {
-		data.Set("WebhooksOnMemberAddedUrl", *params.WebhooksOnMemberAddedUrl)
+		data.Set("Webhooks.OnMemberAdded.Url", *params.WebhooksOnMemberAddedUrl)
 	}
 	if params != nil && params.WebhooksOnMemberRemoveMethod != nil {
-		data.Set("WebhooksOnMemberRemoveMethod", *params.WebhooksOnMemberRemoveMethod)
+		data.Set("Webhooks.OnMemberRemove.Method", *params.WebhooksOnMemberRemoveMethod)
 	}
 	if params != nil && params.WebhooksOnMemberRemoveUrl != nil {
-		data.Set("WebhooksOnMemberRemoveUrl", *params.WebhooksOnMemberRemoveUrl)
+		data.Set("Webhooks.OnMemberRemove.Url", *params.WebhooksOnMemberRemoveUrl)
 	}
 	if params != nil && params.WebhooksOnMemberRemovedMethod != nil {
-		data.Set("WebhooksOnMemberRemovedMethod", *params.WebhooksOnMemberRemovedMethod)
+		data.Set("Webhooks.OnMemberRemoved.Method", *params.WebhooksOnMemberRemovedMethod)
 	}
 	if params != nil && params.WebhooksOnMemberRemovedUrl != nil {
-		data.Set("WebhooksOnMemberRemovedUrl", *params.WebhooksOnMemberRemovedUrl)
+		data.Set("Webhooks.OnMemberRemoved.Url", *params.WebhooksOnMemberRemovedUrl)
 	}
 	if params != nil && params.WebhooksOnMessageRemoveMethod != nil {
-		data.Set("WebhooksOnMessageRemoveMethod", *params.WebhooksOnMessageRemoveMethod)
+		data.Set("Webhooks.OnMessageRemove.Method", *params.WebhooksOnMessageRemoveMethod)
 	}
 	if params != nil && params.WebhooksOnMessageRemoveUrl != nil {
-		data.Set("WebhooksOnMessageRemoveUrl", *params.WebhooksOnMessageRemoveUrl)
+		data.Set("Webhooks.OnMessageRemove.Url", *params.WebhooksOnMessageRemoveUrl)
 	}
 	if params != nil && params.WebhooksOnMessageRemovedMethod != nil {
-		data.Set("WebhooksOnMessageRemovedMethod", *params.WebhooksOnMessageRemovedMethod)
+		data.Set("Webhooks.OnMessageRemoved.Method", *params.WebhooksOnMessageRemovedMethod)
 	}
 	if params != nil && params.WebhooksOnMessageRemovedUrl != nil {
-		data.Set("WebhooksOnMessageRemovedUrl", *params.WebhooksOnMessageRemovedUrl)
+		data.Set("Webhooks.OnMessageRemoved.Url", *params.WebhooksOnMessageRemovedUrl)
 	}
 	if params != nil && params.WebhooksOnMessageSendMethod != nil {
-		data.Set("WebhooksOnMessageSendMethod", *params.WebhooksOnMessageSendMethod)
+		data.Set("Webhooks.OnMessageSend.Method", *params.WebhooksOnMessageSendMethod)
 	}
 	if params != nil && params.WebhooksOnMessageSendUrl != nil {
-		data.Set("WebhooksOnMessageSendUrl", *params.WebhooksOnMessageSendUrl)
+		data.Set("Webhooks.OnMessageSend.Url", *params.WebhooksOnMessageSendUrl)
 	}
 	if params != nil && params.WebhooksOnMessageSentMethod != nil {
-		data.Set("WebhooksOnMessageSentMethod", *params.WebhooksOnMessageSentMethod)
+		data.Set("Webhooks.OnMessageSent.Method", *params.WebhooksOnMessageSentMethod)
 	}
 	if params != nil && params.WebhooksOnMessageSentUrl != nil {
-		data.Set("WebhooksOnMessageSentUrl", *params.WebhooksOnMessageSentUrl)
+		data.Set("Webhooks.OnMessageSent.Url", *params.WebhooksOnMessageSentUrl)
 	}
 	if params != nil && params.WebhooksOnMessageUpdateMethod != nil {
-		data.Set("WebhooksOnMessageUpdateMethod", *params.WebhooksOnMessageUpdateMethod)
+		data.Set("Webhooks.OnMessageUpdate.Method", *params.WebhooksOnMessageUpdateMethod)
 	}
 	if params != nil && params.WebhooksOnMessageUpdateUrl != nil {
-		data.Set("WebhooksOnMessageUpdateUrl", *params.WebhooksOnMessageUpdateUrl)
+		data.Set("Webhooks.OnMessageUpdate.Url", *params.WebhooksOnMessageUpdateUrl)
 	}
 	if params != nil && params.WebhooksOnMessageUpdatedMethod != nil {
-		data.Set("WebhooksOnMessageUpdatedMethod", *params.WebhooksOnMessageUpdatedMethod)
+		data.Set("Webhooks.OnMessageUpdated.Method", *params.WebhooksOnMessageUpdatedMethod)
 	}
 	if params != nil && params.WebhooksOnMessageUpdatedUrl != nil {
-		data.Set("WebhooksOnMessageUpdatedUrl", *params.WebhooksOnMessageUpdatedUrl)
+		data.Set("Webhooks.OnMessageUpdated.Url", *params.WebhooksOnMessageUpdatedUrl)
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)

--- a/twilio/rest/ip_messaging/v1/docs/DefaultApi.md
+++ b/twilio/rest/ip_messaging/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://ip-messaging.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/ip_messaging/v2/README.md
+++ b/twilio/rest/ip_messaging/v2/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://ip-messaging.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/ip_messaging/v2/api_default.go
+++ b/twilio/rest/ip_messaging/v2/api_default.go
@@ -89,7 +89,7 @@ func (c *DefaultApiService) CreateChannel(ServiceSid string, params *CreateChann
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -141,22 +141,22 @@ func (c *DefaultApiService) CreateChannelWebhook(ServiceSid string, ChannelSid s
 	headers := make(map[string]interface{})
 
 	if params != nil && params.ConfigurationFilters != nil {
-		data.Set("ConfigurationFilters", strings.Join(*params.ConfigurationFilters, ","))
+		data.Set("Configuration.Filters", strings.Join(*params.ConfigurationFilters, ","))
 	}
 	if params != nil && params.ConfigurationFlowSid != nil {
-		data.Set("ConfigurationFlowSid", *params.ConfigurationFlowSid)
+		data.Set("Configuration.FlowSid", *params.ConfigurationFlowSid)
 	}
 	if params != nil && params.ConfigurationMethod != nil {
-		data.Set("ConfigurationMethod", *params.ConfigurationMethod)
+		data.Set("Configuration.Method", *params.ConfigurationMethod)
 	}
 	if params != nil && params.ConfigurationRetryCount != nil {
-		data.Set("ConfigurationRetryCount", fmt.Sprint(*params.ConfigurationRetryCount))
+		data.Set("Configuration.RetryCount", fmt.Sprint(*params.ConfigurationRetryCount))
 	}
 	if params != nil && params.ConfigurationTriggers != nil {
-		data.Set("ConfigurationTriggers", strings.Join(*params.ConfigurationTriggers, ","))
+		data.Set("Configuration.Triggers", strings.Join(*params.ConfigurationTriggers, ","))
 	}
 	if params != nil && params.ConfigurationUrl != nil {
-		data.Set("ConfigurationUrl", *params.ConfigurationUrl)
+		data.Set("Configuration.Url", *params.ConfigurationUrl)
 	}
 	if params != nil && params.Type != nil {
 		data.Set("Type", *params.Type)
@@ -346,7 +346,7 @@ func (c *DefaultApiService) CreateMember(ServiceSid string, ChannelSid string, p
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -422,7 +422,7 @@ func (c *DefaultApiService) CreateMessage(ServiceSid string, ChannelSid string, 
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -565,7 +565,7 @@ func (c *DefaultApiService) CreateUser(ServiceSid string, params *CreateUserPara
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -627,7 +627,7 @@ func (c *DefaultApiService) DeleteChannel(ServiceSid string, Sid string, params 
 	headers := make(map[string]interface{})
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Delete(c.baseURL+path, data, headers)
@@ -734,7 +734,7 @@ func (c *DefaultApiService) DeleteMember(ServiceSid string, ChannelSid string, S
 	headers := make(map[string]interface{})
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Delete(c.baseURL+path, data, headers)
@@ -770,7 +770,7 @@ func (c *DefaultApiService) DeleteMessage(ServiceSid string, ChannelSid string, 
 	headers := make(map[string]interface{})
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Delete(c.baseURL+path, data, headers)
@@ -1808,7 +1808,7 @@ func (c *DefaultApiService) UpdateChannel(ServiceSid string, Sid string, params 
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -1860,22 +1860,22 @@ func (c *DefaultApiService) UpdateChannelWebhook(ServiceSid string, ChannelSid s
 	headers := make(map[string]interface{})
 
 	if params != nil && params.ConfigurationFilters != nil {
-		data.Set("ConfigurationFilters", strings.Join(*params.ConfigurationFilters, ","))
+		data.Set("Configuration.Filters", strings.Join(*params.ConfigurationFilters, ","))
 	}
 	if params != nil && params.ConfigurationFlowSid != nil {
-		data.Set("ConfigurationFlowSid", *params.ConfigurationFlowSid)
+		data.Set("Configuration.FlowSid", *params.ConfigurationFlowSid)
 	}
 	if params != nil && params.ConfigurationMethod != nil {
-		data.Set("ConfigurationMethod", *params.ConfigurationMethod)
+		data.Set("Configuration.Method", *params.ConfigurationMethod)
 	}
 	if params != nil && params.ConfigurationRetryCount != nil {
-		data.Set("ConfigurationRetryCount", fmt.Sprint(*params.ConfigurationRetryCount))
+		data.Set("Configuration.RetryCount", fmt.Sprint(*params.ConfigurationRetryCount))
 	}
 	if params != nil && params.ConfigurationTriggers != nil {
-		data.Set("ConfigurationTriggers", strings.Join(*params.ConfigurationTriggers, ","))
+		data.Set("Configuration.Triggers", strings.Join(*params.ConfigurationTriggers, ","))
 	}
 	if params != nil && params.ConfigurationUrl != nil {
-		data.Set("ConfigurationUrl", *params.ConfigurationUrl)
+		data.Set("Configuration.Url", *params.ConfigurationUrl)
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -2011,7 +2011,7 @@ func (c *DefaultApiService) UpdateMember(ServiceSid string, ChannelSid string, S
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -2084,7 +2084,7 @@ func (c *DefaultApiService) UpdateMessage(ServiceSid string, ChannelSid string, 
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -2237,55 +2237,55 @@ func (c *DefaultApiService) UpdateService(Sid string, params *UpdateServiceParam
 		data.Set("FriendlyName", *params.FriendlyName)
 	}
 	if params != nil && params.LimitsChannelMembers != nil {
-		data.Set("LimitsChannelMembers", fmt.Sprint(*params.LimitsChannelMembers))
+		data.Set("Limits.ChannelMembers", fmt.Sprint(*params.LimitsChannelMembers))
 	}
 	if params != nil && params.LimitsUserChannels != nil {
-		data.Set("LimitsUserChannels", fmt.Sprint(*params.LimitsUserChannels))
+		data.Set("Limits.UserChannels", fmt.Sprint(*params.LimitsUserChannels))
 	}
 	if params != nil && params.MediaCompatibilityMessage != nil {
-		data.Set("MediaCompatibilityMessage", *params.MediaCompatibilityMessage)
+		data.Set("Media.CompatibilityMessage", *params.MediaCompatibilityMessage)
 	}
 	if params != nil && params.NotificationsAddedToChannelEnabled != nil {
-		data.Set("NotificationsAddedToChannelEnabled", fmt.Sprint(*params.NotificationsAddedToChannelEnabled))
+		data.Set("Notifications.AddedToChannel.Enabled", fmt.Sprint(*params.NotificationsAddedToChannelEnabled))
 	}
 	if params != nil && params.NotificationsAddedToChannelSound != nil {
-		data.Set("NotificationsAddedToChannelSound", *params.NotificationsAddedToChannelSound)
+		data.Set("Notifications.AddedToChannel.Sound", *params.NotificationsAddedToChannelSound)
 	}
 	if params != nil && params.NotificationsAddedToChannelTemplate != nil {
-		data.Set("NotificationsAddedToChannelTemplate", *params.NotificationsAddedToChannelTemplate)
+		data.Set("Notifications.AddedToChannel.Template", *params.NotificationsAddedToChannelTemplate)
 	}
 	if params != nil && params.NotificationsInvitedToChannelEnabled != nil {
-		data.Set("NotificationsInvitedToChannelEnabled", fmt.Sprint(*params.NotificationsInvitedToChannelEnabled))
+		data.Set("Notifications.InvitedToChannel.Enabled", fmt.Sprint(*params.NotificationsInvitedToChannelEnabled))
 	}
 	if params != nil && params.NotificationsInvitedToChannelSound != nil {
-		data.Set("NotificationsInvitedToChannelSound", *params.NotificationsInvitedToChannelSound)
+		data.Set("Notifications.InvitedToChannel.Sound", *params.NotificationsInvitedToChannelSound)
 	}
 	if params != nil && params.NotificationsInvitedToChannelTemplate != nil {
-		data.Set("NotificationsInvitedToChannelTemplate", *params.NotificationsInvitedToChannelTemplate)
+		data.Set("Notifications.InvitedToChannel.Template", *params.NotificationsInvitedToChannelTemplate)
 	}
 	if params != nil && params.NotificationsLogEnabled != nil {
-		data.Set("NotificationsLogEnabled", fmt.Sprint(*params.NotificationsLogEnabled))
+		data.Set("Notifications.LogEnabled", fmt.Sprint(*params.NotificationsLogEnabled))
 	}
 	if params != nil && params.NotificationsNewMessageBadgeCountEnabled != nil {
-		data.Set("NotificationsNewMessageBadgeCountEnabled", fmt.Sprint(*params.NotificationsNewMessageBadgeCountEnabled))
+		data.Set("Notifications.NewMessage.BadgeCountEnabled", fmt.Sprint(*params.NotificationsNewMessageBadgeCountEnabled))
 	}
 	if params != nil && params.NotificationsNewMessageEnabled != nil {
-		data.Set("NotificationsNewMessageEnabled", fmt.Sprint(*params.NotificationsNewMessageEnabled))
+		data.Set("Notifications.NewMessage.Enabled", fmt.Sprint(*params.NotificationsNewMessageEnabled))
 	}
 	if params != nil && params.NotificationsNewMessageSound != nil {
-		data.Set("NotificationsNewMessageSound", *params.NotificationsNewMessageSound)
+		data.Set("Notifications.NewMessage.Sound", *params.NotificationsNewMessageSound)
 	}
 	if params != nil && params.NotificationsNewMessageTemplate != nil {
-		data.Set("NotificationsNewMessageTemplate", *params.NotificationsNewMessageTemplate)
+		data.Set("Notifications.NewMessage.Template", *params.NotificationsNewMessageTemplate)
 	}
 	if params != nil && params.NotificationsRemovedFromChannelEnabled != nil {
-		data.Set("NotificationsRemovedFromChannelEnabled", fmt.Sprint(*params.NotificationsRemovedFromChannelEnabled))
+		data.Set("Notifications.RemovedFromChannel.Enabled", fmt.Sprint(*params.NotificationsRemovedFromChannelEnabled))
 	}
 	if params != nil && params.NotificationsRemovedFromChannelSound != nil {
-		data.Set("NotificationsRemovedFromChannelSound", *params.NotificationsRemovedFromChannelSound)
+		data.Set("Notifications.RemovedFromChannel.Sound", *params.NotificationsRemovedFromChannelSound)
 	}
 	if params != nil && params.NotificationsRemovedFromChannelTemplate != nil {
-		data.Set("NotificationsRemovedFromChannelTemplate", *params.NotificationsRemovedFromChannelTemplate)
+		data.Set("Notifications.RemovedFromChannel.Template", *params.NotificationsRemovedFromChannelTemplate)
 	}
 	if params != nil && params.PostWebhookRetryCount != nil {
 		data.Set("PostWebhookRetryCount", fmt.Sprint(*params.PostWebhookRetryCount))
@@ -2368,7 +2368,7 @@ func (c *DefaultApiService) UpdateUser(ServiceSid string, Sid string, params *Up
 	}
 
 	if params != nil && params.XTwilioWebhookEnabled != nil {
-		headers["XTwilioWebhookEnabled"] = *params.XTwilioWebhookEnabled
+		headers["X-Twilio-Webhook-Enabled"] = *params.XTwilioWebhookEnabled
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)

--- a/twilio/rest/ip_messaging/v2/docs/DefaultApi.md
+++ b/twilio/rest/ip_messaging/v2/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://ip-messaging.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/lookups/v1/README.md
+++ b/twilio/rest/lookups/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://lookups.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/lookups/v1/docs/DefaultApi.md
+++ b/twilio/rest/lookups/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://lookups.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/messaging/v1/README.md
+++ b/twilio/rest/messaging/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://messaging.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/messaging/v1/docs/DefaultApi.md
+++ b/twilio/rest/messaging/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://messaging.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/monitor/v1/README.md
+++ b/twilio/rest/monitor/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://monitor.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/monitor/v1/docs/DefaultApi.md
+++ b/twilio/rest/monitor/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://monitor.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/notify/v1/README.md
+++ b/twilio/rest/notify/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://notify.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/notify/v1/docs/DefaultApi.md
+++ b/twilio/rest/notify/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://notify.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/numbers/v2/README.md
+++ b/twilio/rest/numbers/v2/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://numbers.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/numbers/v2/docs/DefaultApi.md
+++ b/twilio/rest/numbers/v2/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://numbers.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
@@ -155,7 +155,7 @@ Name | Type | Description
 
 ### HTTP request headers
 
-- **Content-Type**: application/x-www-form-urlencoded, 
+- **Content-Type**: Not defined
 - **Accept**: application/json, 
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)

--- a/twilio/rest/pricing/v1/README.md
+++ b/twilio/rest/pricing/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://pricing.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/pricing/v1/docs/DefaultApi.md
+++ b/twilio/rest/pricing/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://pricing.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/pricing/v2/README.md
+++ b/twilio/rest/pricing/v2/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://pricing.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/pricing/v2/docs/DefaultApi.md
+++ b/twilio/rest/pricing/v2/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://pricing.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/proxy/v1/README.md
+++ b/twilio/rest/proxy/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://proxy.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/proxy/v1/docs/DefaultApi.md
+++ b/twilio/rest/proxy/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://proxy.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/serverless/v1/README.md
+++ b/twilio/rest/serverless/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://serverless.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/serverless/v1/docs/DefaultApi.md
+++ b/twilio/rest/serverless/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://serverless.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/studio/v1/README.md
+++ b/twilio/rest/studio/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://studio.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/studio/v1/docs/DefaultApi.md
+++ b/twilio/rest/studio/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://studio.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/studio/v2/README.md
+++ b/twilio/rest/studio/v2/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://studio.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/studio/v2/docs/DefaultApi.md
+++ b/twilio/rest/studio/v2/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://studio.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/supersim/v1/README.md
+++ b/twilio/rest/supersim/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://supersim.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/supersim/v1/docs/DefaultApi.md
+++ b/twilio/rest/supersim/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://supersim.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/sync/v1/README.md
+++ b/twilio/rest/sync/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://sync.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/sync/v1/api_default.go
+++ b/twilio/rest/sync/v1/api_default.go
@@ -582,7 +582,7 @@ func (c *DefaultApiService) DeleteSyncListItem(ServiceSid string, ListSid string
 	headers := make(map[string]interface{})
 
 	if params != nil && params.IfMatch != nil {
-		headers["IfMatch"] = *params.IfMatch
+		headers["If-Match"] = *params.IfMatch
 	}
 
 	resp, err := c.client.Delete(c.baseURL+path, data, headers)
@@ -667,7 +667,7 @@ func (c *DefaultApiService) DeleteSyncMapItem(ServiceSid string, MapSid string, 
 	headers := make(map[string]interface{})
 
 	if params != nil && params.IfMatch != nil {
-		headers["IfMatch"] = *params.IfMatch
+		headers["If-Match"] = *params.IfMatch
 	}
 
 	resp, err := c.client.Delete(c.baseURL+path, data, headers)
@@ -1493,7 +1493,7 @@ func (c *DefaultApiService) UpdateDocument(ServiceSid string, Sid string, params
 	}
 
 	if params != nil && params.IfMatch != nil {
-		headers["IfMatch"] = *params.IfMatch
+		headers["If-Match"] = *params.IfMatch
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -1728,7 +1728,7 @@ func (c *DefaultApiService) UpdateSyncListItem(ServiceSid string, ListSid string
 	}
 
 	if params != nil && params.IfMatch != nil {
-		headers["IfMatch"] = *params.IfMatch
+		headers["If-Match"] = *params.IfMatch
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)
@@ -1895,7 +1895,7 @@ func (c *DefaultApiService) UpdateSyncMapItem(ServiceSid string, MapSid string, 
 	}
 
 	if params != nil && params.IfMatch != nil {
-		headers["IfMatch"] = *params.IfMatch
+		headers["If-Match"] = *params.IfMatch
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)

--- a/twilio/rest/sync/v1/docs/DefaultApi.md
+++ b/twilio/rest/sync/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://sync.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/taskrouter/v1/README.md
+++ b/twilio/rest/taskrouter/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://taskrouter.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/taskrouter/v1/api_default.go
+++ b/twilio/rest/taskrouter/v1/api_default.go
@@ -2340,7 +2340,7 @@ func (c *DefaultApiService) UpdateTask(WorkspaceSid string, Sid string, params *
 	}
 
 	if params != nil && params.IfMatch != nil {
-		headers["IfMatch"] = *params.IfMatch
+		headers["If-Match"] = *params.IfMatch
 	}
 
 	resp, err := c.client.Post(c.baseURL+path, data, headers)

--- a/twilio/rest/taskrouter/v1/docs/DefaultApi.md
+++ b/twilio/rest/taskrouter/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://taskrouter.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/trunking/v1/README.md
+++ b/twilio/rest/trunking/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://trunking.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/trunking/v1/docs/DefaultApi.md
+++ b/twilio/rest/trunking/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://trunking.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/trusthub/v1/README.md
+++ b/twilio/rest/trusthub/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://trusthub.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/trusthub/v1/docs/DefaultApi.md
+++ b/twilio/rest/trusthub/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://trusthub.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/verify/v2/README.md
+++ b/twilio/rest/verify/v2/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://verify.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/verify/v2/api_default.go
+++ b/twilio/rest/verify/v2/api_default.go
@@ -160,10 +160,10 @@ func (c *DefaultApiService) CreateChallenge(ServiceSid string, Identity string, 
 			return nil, err
 		}
 
-		data.Set("DetailsFields", string(v))
+		data.Set("Details.Fields", string(v))
 	}
 	if params != nil && params.DetailsMessage != nil {
-		data.Set("DetailsMessage", *params.DetailsMessage)
+		data.Set("Details.Message", *params.DetailsMessage)
 	}
 	if params != nil && params.ExpirationDate != nil {
 		data.Set("ExpirationDate", fmt.Sprint((*params.ExpirationDate).Format(time.RFC3339)))
@@ -326,37 +326,37 @@ func (c *DefaultApiService) CreateNewFactor(ServiceSid string, Identity string, 
 	headers := make(map[string]interface{})
 
 	if params != nil && params.BindingAlg != nil {
-		data.Set("BindingAlg", *params.BindingAlg)
+		data.Set("Binding.Alg", *params.BindingAlg)
 	}
 	if params != nil && params.BindingPublicKey != nil {
-		data.Set("BindingPublicKey", *params.BindingPublicKey)
+		data.Set("Binding.PublicKey", *params.BindingPublicKey)
 	}
 	if params != nil && params.BindingSecret != nil {
-		data.Set("BindingSecret", *params.BindingSecret)
+		data.Set("Binding.Secret", *params.BindingSecret)
 	}
 	if params != nil && params.ConfigAlg != nil {
-		data.Set("ConfigAlg", *params.ConfigAlg)
+		data.Set("Config.Alg", *params.ConfigAlg)
 	}
 	if params != nil && params.ConfigAppId != nil {
-		data.Set("ConfigAppId", *params.ConfigAppId)
+		data.Set("Config.AppId", *params.ConfigAppId)
 	}
 	if params != nil && params.ConfigCodeLength != nil {
-		data.Set("ConfigCodeLength", fmt.Sprint(*params.ConfigCodeLength))
+		data.Set("Config.CodeLength", fmt.Sprint(*params.ConfigCodeLength))
 	}
 	if params != nil && params.ConfigNotificationPlatform != nil {
-		data.Set("ConfigNotificationPlatform", *params.ConfigNotificationPlatform)
+		data.Set("Config.NotificationPlatform", *params.ConfigNotificationPlatform)
 	}
 	if params != nil && params.ConfigNotificationToken != nil {
-		data.Set("ConfigNotificationToken", *params.ConfigNotificationToken)
+		data.Set("Config.NotificationToken", *params.ConfigNotificationToken)
 	}
 	if params != nil && params.ConfigSdkVersion != nil {
-		data.Set("ConfigSdkVersion", *params.ConfigSdkVersion)
+		data.Set("Config.SdkVersion", *params.ConfigSdkVersion)
 	}
 	if params != nil && params.ConfigSkew != nil {
-		data.Set("ConfigSkew", fmt.Sprint(*params.ConfigSkew))
+		data.Set("Config.Skew", fmt.Sprint(*params.ConfigSkew))
 	}
 	if params != nil && params.ConfigTimeStep != nil {
-		data.Set("ConfigTimeStep", fmt.Sprint(*params.ConfigTimeStep))
+		data.Set("Config.TimeStep", fmt.Sprint(*params.ConfigTimeStep))
 	}
 	if params != nil && params.FactorType != nil {
 		data.Set("FactorType", *params.FactorType)
@@ -486,13 +486,13 @@ func (c *DefaultApiService) CreateService(params *CreateServiceParams) (*VerifyV
 		data.Set("Psd2Enabled", fmt.Sprint(*params.Psd2Enabled))
 	}
 	if params != nil && params.PushApnCredentialSid != nil {
-		data.Set("PushApnCredentialSid", *params.PushApnCredentialSid)
+		data.Set("Push.ApnCredentialSid", *params.PushApnCredentialSid)
 	}
 	if params != nil && params.PushFcmCredentialSid != nil {
-		data.Set("PushFcmCredentialSid", *params.PushFcmCredentialSid)
+		data.Set("Push.FcmCredentialSid", *params.PushFcmCredentialSid)
 	}
 	if params != nil && params.PushIncludeDate != nil {
-		data.Set("PushIncludeDate", fmt.Sprint(*params.PushIncludeDate))
+		data.Set("Push.IncludeDate", fmt.Sprint(*params.PushIncludeDate))
 	}
 	if params != nil && params.SkipSmsToLandlines != nil {
 		data.Set("SkipSmsToLandlines", fmt.Sprint(*params.SkipSmsToLandlines))
@@ -1553,7 +1553,7 @@ func (c *DefaultApiService) ListVerificationAttempt(params *ListVerificationAtte
 		data.Set("DateCreatedBefore", fmt.Sprint((*params.DateCreatedBefore).Format(time.RFC3339)))
 	}
 	if params != nil && params.ChannelDataTo != nil {
-		data.Set("ChannelDataTo", *params.ChannelDataTo)
+		data.Set("ChannelData.To", *params.ChannelDataTo)
 	}
 	if params != nil && params.PageSize != nil {
 		data.Set("PageSize", fmt.Sprint(*params.PageSize))
@@ -1746,22 +1746,22 @@ func (c *DefaultApiService) UpdateFactor(ServiceSid string, Identity string, Sid
 		data.Set("AuthPayload", *params.AuthPayload)
 	}
 	if params != nil && params.ConfigAlg != nil {
-		data.Set("ConfigAlg", *params.ConfigAlg)
+		data.Set("Config.Alg", *params.ConfigAlg)
 	}
 	if params != nil && params.ConfigCodeLength != nil {
-		data.Set("ConfigCodeLength", fmt.Sprint(*params.ConfigCodeLength))
+		data.Set("Config.CodeLength", fmt.Sprint(*params.ConfigCodeLength))
 	}
 	if params != nil && params.ConfigNotificationToken != nil {
-		data.Set("ConfigNotificationToken", *params.ConfigNotificationToken)
+		data.Set("Config.NotificationToken", *params.ConfigNotificationToken)
 	}
 	if params != nil && params.ConfigSdkVersion != nil {
-		data.Set("ConfigSdkVersion", *params.ConfigSdkVersion)
+		data.Set("Config.SdkVersion", *params.ConfigSdkVersion)
 	}
 	if params != nil && params.ConfigSkew != nil {
-		data.Set("ConfigSkew", fmt.Sprint(*params.ConfigSkew))
+		data.Set("Config.Skew", fmt.Sprint(*params.ConfigSkew))
 	}
 	if params != nil && params.ConfigTimeStep != nil {
-		data.Set("ConfigTimeStep", fmt.Sprint(*params.ConfigTimeStep))
+		data.Set("Config.TimeStep", fmt.Sprint(*params.ConfigTimeStep))
 	}
 	if params != nil && params.FriendlyName != nil {
 		data.Set("FriendlyName", *params.FriendlyName)
@@ -1928,13 +1928,13 @@ func (c *DefaultApiService) UpdateService(Sid string, params *UpdateServiceParam
 		data.Set("Psd2Enabled", fmt.Sprint(*params.Psd2Enabled))
 	}
 	if params != nil && params.PushApnCredentialSid != nil {
-		data.Set("PushApnCredentialSid", *params.PushApnCredentialSid)
+		data.Set("Push.ApnCredentialSid", *params.PushApnCredentialSid)
 	}
 	if params != nil && params.PushFcmCredentialSid != nil {
-		data.Set("PushFcmCredentialSid", *params.PushFcmCredentialSid)
+		data.Set("Push.FcmCredentialSid", *params.PushFcmCredentialSid)
 	}
 	if params != nil && params.PushIncludeDate != nil {
-		data.Set("PushIncludeDate", fmt.Sprint(*params.PushIncludeDate))
+		data.Set("Push.IncludeDate", fmt.Sprint(*params.PushIncludeDate))
 	}
 	if params != nil && params.SkipSmsToLandlines != nil {
 		data.Set("SkipSmsToLandlines", fmt.Sprint(*params.SkipSmsToLandlines))

--- a/twilio/rest/verify/v2/docs/DefaultApi.md
+++ b/twilio/rest/verify/v2/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://verify.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/video/v1/README.md
+++ b/twilio/rest/video/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://video.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/video/v1/docs/DefaultApi.md
+++ b/twilio/rest/video/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://video.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/voice/v1/README.md
+++ b/twilio/rest/voice/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://voice.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/voice/v1/docs/DefaultApi.md
+++ b/twilio/rest/voice/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://voice.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/twilio/rest/wireless/v1/README.md
+++ b/twilio/rest/wireless/v1/README.md
@@ -27,7 +27,7 @@ import "./openapi"
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://wireless.twilio.com*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/twilio/rest/wireless/v1/docs/DefaultApi.md
+++ b/twilio/rest/wireless/v1/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://wireless.twilio.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------


### PR DESCRIPTION
# Fixes #

Fixes parameter names such as `Integration.Url` and `DateCreated<`

Related to: https://github.com/twilio/twilio-oai-generator/pull/30

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-go/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
