### PR TITLE
chore: update github action linter

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: golangci-lint
-        uses: golangci/golangcli-lint-action@v2
+        uses: golangci/golangci-lint-action@v2.5.2
         with:
           version: latest
           github_token: ${{ secrets.github_token }}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,6 +13,6 @@ jobs:
         uses: golangci/golangci-lint-action@v2.5.2
         with:
           version: latest
-          github_token: ${{ secrets.github_token }}
+          github-token: ${{ secrets.github_token }}
           args: "--enable-all --exclude-use-default=false -D errcheck -D gomnd"
           only-new-issues: true

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,16 +1,18 @@
-name: reviewdog
+name: golangci-lint
 on: [pull_request]
 jobs:
   golangci-lint:
-    name: runner / golangci-lint
+    name: lint
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
-      - name: golangci-lint
-        uses: docker://reviewdog/action-golangci-lint:v1
+        uses: actions/checkout@v2
         with:
+          fetch-depth: 0
+      - name: golangci-lint
+        uses: golangci/golangcli-lint-action@v2
+        with:
+          version: latest
           github_token: ${{ secrets.github_token }}
-          golangci_lint_flags: "--enable-all --exclude-use-default=false -D errcheck -D gomnd"
-          level: error
-          tool_name: golint
+          args: "--enable-all --exclude-use-default=false -D errcheck -D gomnd"
+          only-new-issues: true

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 .idea
+*.iml
 
 **/.openapi-generator
 


### PR DESCRIPTION
This PR updates the GitHub action linter to use the [officially supported golangci-lint GitHub action](https://github.com/golangci/golangci-lint-action)