### PR TITLE
chore: add check in BuildHost function

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -51,11 +51,11 @@ func (c *Client) BuildHost(rawHost string) string {
 	var (
 		edge    = ""
 		region  = ""
-		suffix  = ""
 		pieces  = strings.Split(rawHost, ".")
 		product = pieces[0]
 		result  = []string{}
 	)
+    suffix  := ""
 
 	if len(pieces) >= 3 {
 		suffix = strings.Join(pieces[len(pieces)-2:], ".")

--- a/client/client.go
+++ b/client/client.go
@@ -55,7 +55,7 @@ func (c *Client) BuildHost(rawHost string) string {
 		product = pieces[0]
 		result  = []string{}
 	)
-    suffix  := ""
+	suffix := ""
 
 	if len(pieces) >= 3 {
 		suffix = strings.Join(pieces[len(pieces)-2:], ".")

--- a/client/client.go
+++ b/client/client.go
@@ -51,11 +51,17 @@ func (c *Client) BuildHost(rawHost string) string {
 	var (
 		edge    = ""
 		region  = ""
+		suffix  = ""
 		pieces  = strings.Split(rawHost, ".")
 		product = pieces[0]
-		suffix  = strings.Join(pieces[len(pieces)-2:], ".")
 		result  = []string{}
 	)
+
+	if len(pieces) >= 3 {
+		suffix = strings.Join(pieces[len(pieces)-2:], ".")
+	} else {
+		return rawHost
+	}
 
 	if len(pieces) == 4 {
 		// product.region.twilio.com

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -171,3 +171,9 @@ func TestClient_BuildHostSetEdgeRegion(t *testing.T) {
 	assert.Equal(t, "https://api.edge.region.twilio.com", client.BuildHost("https://api.twilio.com"))
 	assert.Equal(t, "https://api.edge.region.twilio.com", client.BuildHost("https://api.urlEdge.urlRegion.twilio.com"))
 }
+
+//nolint:paralleltest
+func TestClient_BuildHostRawHostWithoutPeriods(t *testing.T) {
+	client := NewClient("user", "pass")
+	assert.Equal(t, "https://prism_twilio:4010", client.BuildHost("https://prism_twilio:4010"))
+}


### PR DESCRIPTION
# Fixes #

Add an additional check to verify that pieces is long enough. This was causing integration tests to fail because the rawHost is `prism_twilio:4010`
Jira Ticket: https://issues.corp.twilio.com/browse/DI-1263
Related PR: https://github.com/twilio/twilio-oai-generator/pull/34

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
