### PR TITLE
chore!: rename Ip_MessagingVx to IpMessagingVx

### DIFF
--- a/twilio.go
+++ b/twilio.go
@@ -17,8 +17,8 @@ import (
 	FaxV1 "github.com/twilio/twilio-go/rest/fax/v1"
 	FlexV1 "github.com/twilio/twilio-go/rest/flex/v1"
 	InsightsV1 "github.com/twilio/twilio-go/rest/insights/v1"
-	Ip_MessagingV1 "github.com/twilio/twilio-go/rest/ip_messaging/v1"
-	Ip_MessagingV2 "github.com/twilio/twilio-go/rest/ip_messaging/v2"
+	IpMessagingV1 "github.com/twilio/twilio-go/rest/ip_messaging/v1"
+	IpMessagingV2 "github.com/twilio/twilio-go/rest/ip_messaging/v2"
 	LookupsV1 "github.com/twilio/twilio-go/rest/lookups/v1"
 	MessagingV1 "github.com/twilio/twilio-go/rest/messaging/v1"
 	MonitorV1 "github.com/twilio/twilio-go/rest/monitor/v1"
@@ -55,8 +55,8 @@ type RestClient struct {
 	FaxV1           *FaxV1.DefaultApiService
 	FlexV1          *FlexV1.DefaultApiService
 	InsightsV1      *InsightsV1.DefaultApiService
-	Ip_MessagingV1  *Ip_MessagingV1.DefaultApiService
-	Ip_MessagingV2  *Ip_MessagingV2.DefaultApiService
+	IpMessagingV1   *IpMessagingV1.DefaultApiService
+	IpMessagingV2   *IpMessagingV2.DefaultApiService
 	LookupsV1       *LookupsV1.DefaultApiService
 	MessagingV1     *MessagingV1.DefaultApiService
 	MonitorV1       *MonitorV1.DefaultApiService
@@ -122,8 +122,8 @@ func NewRestClientWithParams(username string, password string, params RestClient
 	c.FaxV1 = FaxV1.NewDefaultApiService(c.Client)
 	c.FlexV1 = FlexV1.NewDefaultApiService(c.Client)
 	c.InsightsV1 = InsightsV1.NewDefaultApiService(c.Client)
-	c.Ip_MessagingV1 = Ip_MessagingV1.NewDefaultApiService(c.Client)
-	c.Ip_MessagingV2 = Ip_MessagingV2.NewDefaultApiService(c.Client)
+	c.IpMessagingV1 = IpMessagingV1.NewDefaultApiService(c.Client)
+	c.IpMessagingV2 = IpMessagingV2.NewDefaultApiService(c.Client)
 	c.LookupsV1 = LookupsV1.NewDefaultApiService(c.Client)
 	c.MessagingV1 = MessagingV1.NewDefaultApiService(c.Client)
 	c.MonitorV1 = MonitorV1.NewDefaultApiService(c.Client)


### PR DESCRIPTION
Rename Ip_MessagingVx in the rest client

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [xx] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-go/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified
