### PR TITLE
fix: refactor limit enforcement and fetching next page

### DIFF
--- a/rest/api/v2010/accounts_addresses_dependent_phone_numbers.go
+++ b/rest/api/v2010/accounts_addresses_dependent_phone_numbers.go
@@ -85,28 +85,15 @@ func (c *ApiService) PageDependentPhoneNumber(AddressSid string, params *ListDep
 
 // Lists DependentPhoneNumber records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListDependentPhoneNumber(AddressSid string, params *ListDependentPhoneNumberParams) ([]ApiV2010DependentPhoneNumber, error) {
-	if params == nil {
-		params = &ListDependentPhoneNumberParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageDependentPhoneNumber(AddressSid, params, "", "")
+	response, err := c.StreamDependentPhoneNumber(AddressSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010DependentPhoneNumber
+	records := make([]ApiV2010DependentPhoneNumber, 0)
 
-	for response != nil {
-		records = append(records, response.DependentPhoneNumbers...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListDependentPhoneNumberResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListDependentPhoneNumberResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -124,18 +111,24 @@ func (c *ApiService) StreamDependentPhoneNumber(AddressSid string, params *ListD
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010DependentPhoneNumber, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.DependentPhoneNumbers {
-				channel <- response.DependentPhoneNumbers[item]
+			responseRecords := response.DependentPhoneNumbers
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListDependentPhoneNumberResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListDependentPhoneNumberResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_available_phone_numbers_mobile.go
+++ b/rest/api/v2010/accounts_available_phone_numbers_mobile.go
@@ -247,28 +247,15 @@ func (c *ApiService) PageAvailablePhoneNumberMobile(CountryCode string, params *
 
 // Lists AvailablePhoneNumberMobile records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListAvailablePhoneNumberMobile(CountryCode string, params *ListAvailablePhoneNumberMobileParams) ([]ApiV2010AvailablePhoneNumberMobile, error) {
-	if params == nil {
-		params = &ListAvailablePhoneNumberMobileParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageAvailablePhoneNumberMobile(CountryCode, params, "", "")
+	response, err := c.StreamAvailablePhoneNumberMobile(CountryCode, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010AvailablePhoneNumberMobile
+	records := make([]ApiV2010AvailablePhoneNumberMobile, 0)
 
-	for response != nil {
-		records = append(records, response.AvailablePhoneNumbers...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListAvailablePhoneNumberMobileResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListAvailablePhoneNumberMobileResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -286,18 +273,24 @@ func (c *ApiService) StreamAvailablePhoneNumberMobile(CountryCode string, params
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010AvailablePhoneNumberMobile, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.AvailablePhoneNumbers {
-				channel <- response.AvailablePhoneNumbers[item]
+			responseRecords := response.AvailablePhoneNumbers
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListAvailablePhoneNumberMobileResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListAvailablePhoneNumberMobileResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_available_phone_numbers_toll_free.go
+++ b/rest/api/v2010/accounts_available_phone_numbers_toll_free.go
@@ -247,28 +247,15 @@ func (c *ApiService) PageAvailablePhoneNumberTollFree(CountryCode string, params
 
 // Lists AvailablePhoneNumberTollFree records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListAvailablePhoneNumberTollFree(CountryCode string, params *ListAvailablePhoneNumberTollFreeParams) ([]ApiV2010AvailablePhoneNumberTollFree, error) {
-	if params == nil {
-		params = &ListAvailablePhoneNumberTollFreeParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageAvailablePhoneNumberTollFree(CountryCode, params, "", "")
+	response, err := c.StreamAvailablePhoneNumberTollFree(CountryCode, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010AvailablePhoneNumberTollFree
+	records := make([]ApiV2010AvailablePhoneNumberTollFree, 0)
 
-	for response != nil {
-		records = append(records, response.AvailablePhoneNumbers...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListAvailablePhoneNumberTollFreeResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListAvailablePhoneNumberTollFreeResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -286,18 +273,24 @@ func (c *ApiService) StreamAvailablePhoneNumberTollFree(CountryCode string, para
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010AvailablePhoneNumberTollFree, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.AvailablePhoneNumbers {
-				channel <- response.AvailablePhoneNumbers[item]
+			responseRecords := response.AvailablePhoneNumbers
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListAvailablePhoneNumberTollFreeResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListAvailablePhoneNumberTollFreeResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_available_phone_numbers_voip.go
+++ b/rest/api/v2010/accounts_available_phone_numbers_voip.go
@@ -247,28 +247,15 @@ func (c *ApiService) PageAvailablePhoneNumberVoip(CountryCode string, params *Li
 
 // Lists AvailablePhoneNumberVoip records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListAvailablePhoneNumberVoip(CountryCode string, params *ListAvailablePhoneNumberVoipParams) ([]ApiV2010AvailablePhoneNumberVoip, error) {
-	if params == nil {
-		params = &ListAvailablePhoneNumberVoipParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageAvailablePhoneNumberVoip(CountryCode, params, "", "")
+	response, err := c.StreamAvailablePhoneNumberVoip(CountryCode, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010AvailablePhoneNumberVoip
+	records := make([]ApiV2010AvailablePhoneNumberVoip, 0)
 
-	for response != nil {
-		records = append(records, response.AvailablePhoneNumbers...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListAvailablePhoneNumberVoipResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListAvailablePhoneNumberVoipResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -286,18 +273,24 @@ func (c *ApiService) StreamAvailablePhoneNumberVoip(CountryCode string, params *
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010AvailablePhoneNumberVoip, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.AvailablePhoneNumbers {
-				channel <- response.AvailablePhoneNumbers[item]
+			responseRecords := response.AvailablePhoneNumbers
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListAvailablePhoneNumberVoipResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListAvailablePhoneNumberVoipResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_calls.go
+++ b/rest/api/v2010/accounts_calls.go
@@ -606,28 +606,15 @@ func (c *ApiService) PageCall(params *ListCallParams, pageToken, pageNumber stri
 
 // Lists Call records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCall(params *ListCallParams) ([]ApiV2010Call, error) {
-	if params == nil {
-		params = &ListCallParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageCall(params, "", "")
+	response, err := c.StreamCall(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010Call
+	records := make([]ApiV2010Call, 0)
 
-	for response != nil {
-		records = append(records, response.Calls...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCallResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListCallResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -645,18 +632,24 @@ func (c *ApiService) StreamCall(params *ListCallParams) (chan ApiV2010Call, erro
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010Call, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Calls {
-				channel <- response.Calls[item]
+			responseRecords := response.Calls
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCallResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListCallResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_calls_recordings.go
+++ b/rest/api/v2010/accounts_calls_recordings.go
@@ -283,28 +283,15 @@ func (c *ApiService) PageCallRecording(CallSid string, params *ListCallRecording
 
 // Lists CallRecording records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCallRecording(CallSid string, params *ListCallRecordingParams) ([]ApiV2010CallRecording, error) {
-	if params == nil {
-		params = &ListCallRecordingParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageCallRecording(CallSid, params, "", "")
+	response, err := c.StreamCallRecording(CallSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010CallRecording
+	records := make([]ApiV2010CallRecording, 0)
 
-	for response != nil {
-		records = append(records, response.Recordings...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCallRecordingResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListCallRecordingResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -322,18 +309,24 @@ func (c *ApiService) StreamCallRecording(CallSid string, params *ListCallRecordi
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010CallRecording, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Recordings {
-				channel <- response.Recordings[item]
+			responseRecords := response.Recordings
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCallRecordingResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListCallRecordingResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_conferences.go
+++ b/rest/api/v2010/accounts_conferences.go
@@ -195,28 +195,15 @@ func (c *ApiService) PageConference(params *ListConferenceParams, pageToken, pag
 
 // Lists Conference records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListConference(params *ListConferenceParams) ([]ApiV2010Conference, error) {
-	if params == nil {
-		params = &ListConferenceParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageConference(params, "", "")
+	response, err := c.StreamConference(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010Conference
+	records := make([]ApiV2010Conference, 0)
 
-	for response != nil {
-		records = append(records, response.Conferences...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListConferenceResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListConferenceResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -234,18 +221,24 @@ func (c *ApiService) StreamConference(params *ListConferenceParams) (chan ApiV20
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010Conference, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Conferences {
-				channel <- response.Conferences[item]
+			responseRecords := response.Conferences
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListConferenceResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListConferenceResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_incoming_phone_numbers.go
+++ b/rest/api/v2010/accounts_incoming_phone_numbers.go
@@ -448,28 +448,15 @@ func (c *ApiService) PageIncomingPhoneNumber(params *ListIncomingPhoneNumberPara
 
 // Lists IncomingPhoneNumber records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListIncomingPhoneNumber(params *ListIncomingPhoneNumberParams) ([]ApiV2010IncomingPhoneNumber, error) {
-	if params == nil {
-		params = &ListIncomingPhoneNumberParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageIncomingPhoneNumber(params, "", "")
+	response, err := c.StreamIncomingPhoneNumber(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010IncomingPhoneNumber
+	records := make([]ApiV2010IncomingPhoneNumber, 0)
 
-	for response != nil {
-		records = append(records, response.IncomingPhoneNumbers...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListIncomingPhoneNumberResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListIncomingPhoneNumberResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -487,18 +474,24 @@ func (c *ApiService) StreamIncomingPhoneNumber(params *ListIncomingPhoneNumberPa
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010IncomingPhoneNumber, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.IncomingPhoneNumbers {
-				channel <- response.IncomingPhoneNumbers[item]
+			responseRecords := response.IncomingPhoneNumbers
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListIncomingPhoneNumberResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListIncomingPhoneNumberResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_incoming_phone_numbers_local.go
+++ b/rest/api/v2010/accounts_incoming_phone_numbers_local.go
@@ -365,28 +365,15 @@ func (c *ApiService) PageIncomingPhoneNumberLocal(params *ListIncomingPhoneNumbe
 
 // Lists IncomingPhoneNumberLocal records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListIncomingPhoneNumberLocal(params *ListIncomingPhoneNumberLocalParams) ([]ApiV2010IncomingPhoneNumberLocal, error) {
-	if params == nil {
-		params = &ListIncomingPhoneNumberLocalParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageIncomingPhoneNumberLocal(params, "", "")
+	response, err := c.StreamIncomingPhoneNumberLocal(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010IncomingPhoneNumberLocal
+	records := make([]ApiV2010IncomingPhoneNumberLocal, 0)
 
-	for response != nil {
-		records = append(records, response.IncomingPhoneNumbers...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListIncomingPhoneNumberLocalResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListIncomingPhoneNumberLocalResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -404,18 +391,24 @@ func (c *ApiService) StreamIncomingPhoneNumberLocal(params *ListIncomingPhoneNum
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010IncomingPhoneNumberLocal, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.IncomingPhoneNumbers {
-				channel <- response.IncomingPhoneNumbers[item]
+			responseRecords := response.IncomingPhoneNumbers
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListIncomingPhoneNumberLocalResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListIncomingPhoneNumberLocalResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_incoming_phone_numbers_mobile.go
+++ b/rest/api/v2010/accounts_incoming_phone_numbers_mobile.go
@@ -365,28 +365,15 @@ func (c *ApiService) PageIncomingPhoneNumberMobile(params *ListIncomingPhoneNumb
 
 // Lists IncomingPhoneNumberMobile records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListIncomingPhoneNumberMobile(params *ListIncomingPhoneNumberMobileParams) ([]ApiV2010IncomingPhoneNumberMobile, error) {
-	if params == nil {
-		params = &ListIncomingPhoneNumberMobileParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageIncomingPhoneNumberMobile(params, "", "")
+	response, err := c.StreamIncomingPhoneNumberMobile(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010IncomingPhoneNumberMobile
+	records := make([]ApiV2010IncomingPhoneNumberMobile, 0)
 
-	for response != nil {
-		records = append(records, response.IncomingPhoneNumbers...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListIncomingPhoneNumberMobileResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListIncomingPhoneNumberMobileResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -404,18 +391,24 @@ func (c *ApiService) StreamIncomingPhoneNumberMobile(params *ListIncomingPhoneNu
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010IncomingPhoneNumberMobile, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.IncomingPhoneNumbers {
-				channel <- response.IncomingPhoneNumbers[item]
+			responseRecords := response.IncomingPhoneNumbers
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListIncomingPhoneNumberMobileResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListIncomingPhoneNumberMobileResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_incoming_phone_numbers_toll_free.go
+++ b/rest/api/v2010/accounts_incoming_phone_numbers_toll_free.go
@@ -365,28 +365,15 @@ func (c *ApiService) PageIncomingPhoneNumberTollFree(params *ListIncomingPhoneNu
 
 // Lists IncomingPhoneNumberTollFree records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListIncomingPhoneNumberTollFree(params *ListIncomingPhoneNumberTollFreeParams) ([]ApiV2010IncomingPhoneNumberTollFree, error) {
-	if params == nil {
-		params = &ListIncomingPhoneNumberTollFreeParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageIncomingPhoneNumberTollFree(params, "", "")
+	response, err := c.StreamIncomingPhoneNumberTollFree(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010IncomingPhoneNumberTollFree
+	records := make([]ApiV2010IncomingPhoneNumberTollFree, 0)
 
-	for response != nil {
-		records = append(records, response.IncomingPhoneNumbers...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListIncomingPhoneNumberTollFreeResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListIncomingPhoneNumberTollFreeResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -404,18 +391,24 @@ func (c *ApiService) StreamIncomingPhoneNumberTollFree(params *ListIncomingPhone
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010IncomingPhoneNumberTollFree, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.IncomingPhoneNumbers {
-				channel <- response.IncomingPhoneNumbers[item]
+			responseRecords := response.IncomingPhoneNumbers
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListIncomingPhoneNumberTollFreeResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListIncomingPhoneNumberTollFreeResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_messages_media.go
+++ b/rest/api/v2010/accounts_messages_media.go
@@ -188,28 +188,15 @@ func (c *ApiService) PageMedia(MessageSid string, params *ListMediaParams, pageT
 
 // Lists Media records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMedia(MessageSid string, params *ListMediaParams) ([]ApiV2010Media, error) {
-	if params == nil {
-		params = &ListMediaParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageMedia(MessageSid, params, "", "")
+	response, err := c.StreamMedia(MessageSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010Media
+	records := make([]ApiV2010Media, 0)
 
-	for response != nil {
-		records = append(records, response.MediaList...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListMediaResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListMediaResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -227,18 +214,24 @@ func (c *ApiService) StreamMedia(MessageSid string, params *ListMediaParams) (ch
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010Media, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.MediaList {
-				channel <- response.MediaList[item]
+			responseRecords := response.MediaList
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListMediaResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListMediaResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_queues.go
+++ b/rest/api/v2010/accounts_queues.go
@@ -214,28 +214,15 @@ func (c *ApiService) PageQueue(params *ListQueueParams, pageToken, pageNumber st
 
 // Lists Queue records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListQueue(params *ListQueueParams) ([]ApiV2010Queue, error) {
-	if params == nil {
-		params = &ListQueueParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageQueue(params, "", "")
+	response, err := c.StreamQueue(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010Queue
+	records := make([]ApiV2010Queue, 0)
 
-	for response != nil {
-		records = append(records, response.Queues...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListQueueResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListQueueResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -253,18 +240,24 @@ func (c *ApiService) StreamQueue(params *ListQueueParams) (chan ApiV2010Queue, e
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010Queue, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Queues {
-				channel <- response.Queues[item]
+			responseRecords := response.Queues
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListQueueResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListQueueResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_recordings.go
+++ b/rest/api/v2010/accounts_recordings.go
@@ -222,28 +222,15 @@ func (c *ApiService) PageRecording(params *ListRecordingParams, pageToken, pageN
 
 // Lists Recording records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRecording(params *ListRecordingParams) ([]ApiV2010Recording, error) {
-	if params == nil {
-		params = &ListRecordingParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageRecording(params, "", "")
+	response, err := c.StreamRecording(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010Recording
+	records := make([]ApiV2010Recording, 0)
 
-	for response != nil {
-		records = append(records, response.Recordings...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRecordingResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListRecordingResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -261,18 +248,24 @@ func (c *ApiService) StreamRecording(params *ListRecordingParams) (chan ApiV2010
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010Recording, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Recordings {
-				channel <- response.Recordings[item]
+			responseRecords := response.Recordings
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRecordingResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListRecordingResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_recordings_add_on_results.go
+++ b/rest/api/v2010/accounts_recordings_add_on_results.go
@@ -160,28 +160,15 @@ func (c *ApiService) PageRecordingAddOnResult(ReferenceSid string, params *ListR
 
 // Lists RecordingAddOnResult records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRecordingAddOnResult(ReferenceSid string, params *ListRecordingAddOnResultParams) ([]ApiV2010RecordingAddOnResult, error) {
-	if params == nil {
-		params = &ListRecordingAddOnResultParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageRecordingAddOnResult(ReferenceSid, params, "", "")
+	response, err := c.StreamRecordingAddOnResult(ReferenceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010RecordingAddOnResult
+	records := make([]ApiV2010RecordingAddOnResult, 0)
 
-	for response != nil {
-		records = append(records, response.AddOnResults...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRecordingAddOnResultResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListRecordingAddOnResultResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -199,18 +186,24 @@ func (c *ApiService) StreamRecordingAddOnResult(ReferenceSid string, params *Lis
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010RecordingAddOnResult, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.AddOnResults {
-				channel <- response.AddOnResults[item]
+			responseRecords := response.AddOnResults
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRecordingAddOnResultResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListRecordingAddOnResultResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_recordings_transcriptions.go
+++ b/rest/api/v2010/accounts_recordings_transcriptions.go
@@ -158,28 +158,15 @@ func (c *ApiService) PageRecordingTranscription(RecordingSid string, params *Lis
 
 // Lists RecordingTranscription records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRecordingTranscription(RecordingSid string, params *ListRecordingTranscriptionParams) ([]ApiV2010RecordingTranscription, error) {
-	if params == nil {
-		params = &ListRecordingTranscriptionParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageRecordingTranscription(RecordingSid, params, "", "")
+	response, err := c.StreamRecordingTranscription(RecordingSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010RecordingTranscription
+	records := make([]ApiV2010RecordingTranscription, 0)
 
-	for response != nil {
-		records = append(records, response.Transcriptions...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRecordingTranscriptionResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListRecordingTranscriptionResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -197,18 +184,24 @@ func (c *ApiService) StreamRecordingTranscription(RecordingSid string, params *L
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010RecordingTranscription, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Transcriptions {
-				channel <- response.Transcriptions[item]
+			responseRecords := response.Transcriptions
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRecordingTranscriptionResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListRecordingTranscriptionResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_sip_credential_lists_credentials.go
+++ b/rest/api/v2010/accounts_sip_credential_lists_credentials.go
@@ -218,28 +218,15 @@ func (c *ApiService) PageSipCredential(CredentialListSid string, params *ListSip
 
 // Lists SipCredential records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSipCredential(CredentialListSid string, params *ListSipCredentialParams) ([]ApiV2010SipCredential, error) {
-	if params == nil {
-		params = &ListSipCredentialParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageSipCredential(CredentialListSid, params, "", "")
+	response, err := c.StreamSipCredential(CredentialListSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010SipCredential
+	records := make([]ApiV2010SipCredential, 0)
 
-	for response != nil {
-		records = append(records, response.Credentials...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSipCredentialResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListSipCredentialResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -257,18 +244,24 @@ func (c *ApiService) StreamSipCredential(CredentialListSid string, params *ListS
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010SipCredential, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Credentials {
-				channel <- response.Credentials[item]
+			responseRecords := response.Credentials
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSipCredentialResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListSipCredentialResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_sip_domains.go
+++ b/rest/api/v2010/accounts_sip_domains.go
@@ -313,28 +313,15 @@ func (c *ApiService) PageSipDomain(params *ListSipDomainParams, pageToken, pageN
 
 // Lists SipDomain records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSipDomain(params *ListSipDomainParams) ([]ApiV2010SipDomain, error) {
-	if params == nil {
-		params = &ListSipDomainParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageSipDomain(params, "", "")
+	response, err := c.StreamSipDomain(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010SipDomain
+	records := make([]ApiV2010SipDomain, 0)
 
-	for response != nil {
-		records = append(records, response.Domains...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSipDomainResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListSipDomainResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -352,18 +339,24 @@ func (c *ApiService) StreamSipDomain(params *ListSipDomainParams) (chan ApiV2010
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010SipDomain, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Domains {
-				channel <- response.Domains[item]
+			responseRecords := response.Domains
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSipDomainResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListSipDomainResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_sip_domains_auth_calls_credential_list_mappings.go
+++ b/rest/api/v2010/accounts_sip_domains_auth_calls_credential_list_mappings.go
@@ -209,28 +209,15 @@ func (c *ApiService) PageSipAuthCallsCredentialListMapping(DomainSid string, par
 
 // Lists SipAuthCallsCredentialListMapping records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSipAuthCallsCredentialListMapping(DomainSid string, params *ListSipAuthCallsCredentialListMappingParams) ([]ApiV2010SipAuthCallsCredentialListMapping, error) {
-	if params == nil {
-		params = &ListSipAuthCallsCredentialListMappingParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageSipAuthCallsCredentialListMapping(DomainSid, params, "", "")
+	response, err := c.StreamSipAuthCallsCredentialListMapping(DomainSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010SipAuthCallsCredentialListMapping
+	records := make([]ApiV2010SipAuthCallsCredentialListMapping, 0)
 
-	for response != nil {
-		records = append(records, response.Contents...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSipAuthCallsCredentialListMappingResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListSipAuthCallsCredentialListMappingResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -248,18 +235,24 @@ func (c *ApiService) StreamSipAuthCallsCredentialListMapping(DomainSid string, p
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010SipAuthCallsCredentialListMapping, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Contents {
-				channel <- response.Contents[item]
+			responseRecords := response.Contents
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSipAuthCallsCredentialListMappingResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListSipAuthCallsCredentialListMappingResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_sip_domains_auth_registrations_credential_list_mappings.go
+++ b/rest/api/v2010/accounts_sip_domains_auth_registrations_credential_list_mappings.go
@@ -209,28 +209,15 @@ func (c *ApiService) PageSipAuthRegistrationsCredentialListMapping(DomainSid str
 
 // Lists SipAuthRegistrationsCredentialListMapping records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSipAuthRegistrationsCredentialListMapping(DomainSid string, params *ListSipAuthRegistrationsCredentialListMappingParams) ([]ApiV2010SipAuthRegistrationsCredentialListMapping, error) {
-	if params == nil {
-		params = &ListSipAuthRegistrationsCredentialListMappingParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageSipAuthRegistrationsCredentialListMapping(DomainSid, params, "", "")
+	response, err := c.StreamSipAuthRegistrationsCredentialListMapping(DomainSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010SipAuthRegistrationsCredentialListMapping
+	records := make([]ApiV2010SipAuthRegistrationsCredentialListMapping, 0)
 
-	for response != nil {
-		records = append(records, response.Contents...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSipAuthRegistrationsCredentialListMappingResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListSipAuthRegistrationsCredentialListMappingResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -248,18 +235,24 @@ func (c *ApiService) StreamSipAuthRegistrationsCredentialListMapping(DomainSid s
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010SipAuthRegistrationsCredentialListMapping, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Contents {
-				channel <- response.Contents[item]
+			responseRecords := response.Contents
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSipAuthRegistrationsCredentialListMappingResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListSipAuthRegistrationsCredentialListMappingResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_sip_domains_ip_access_control_list_mappings.go
+++ b/rest/api/v2010/accounts_sip_domains_ip_access_control_list_mappings.go
@@ -209,28 +209,15 @@ func (c *ApiService) PageSipIpAccessControlListMapping(DomainSid string, params 
 
 // Lists SipIpAccessControlListMapping records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSipIpAccessControlListMapping(DomainSid string, params *ListSipIpAccessControlListMappingParams) ([]ApiV2010SipIpAccessControlListMapping, error) {
-	if params == nil {
-		params = &ListSipIpAccessControlListMappingParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageSipIpAccessControlListMapping(DomainSid, params, "", "")
+	response, err := c.StreamSipIpAccessControlListMapping(DomainSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010SipIpAccessControlListMapping
+	records := make([]ApiV2010SipIpAccessControlListMapping, 0)
 
-	for response != nil {
-		records = append(records, response.IpAccessControlListMappings...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSipIpAccessControlListMappingResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListSipIpAccessControlListMappingResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -248,18 +235,24 @@ func (c *ApiService) StreamSipIpAccessControlListMapping(DomainSid string, param
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010SipIpAccessControlListMapping, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.IpAccessControlListMappings {
-				channel <- response.IpAccessControlListMappings[item]
+			responseRecords := response.IpAccessControlListMappings
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSipIpAccessControlListMappingResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListSipIpAccessControlListMappingResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_sipip_access_control_lists.go
+++ b/rest/api/v2010/accounts_sipip_access_control_lists.go
@@ -205,28 +205,15 @@ func (c *ApiService) PageSipIpAccessControlList(params *ListSipIpAccessControlLi
 
 // Lists SipIpAccessControlList records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSipIpAccessControlList(params *ListSipIpAccessControlListParams) ([]ApiV2010SipIpAccessControlList, error) {
-	if params == nil {
-		params = &ListSipIpAccessControlListParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageSipIpAccessControlList(params, "", "")
+	response, err := c.StreamSipIpAccessControlList(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010SipIpAccessControlList
+	records := make([]ApiV2010SipIpAccessControlList, 0)
 
-	for response != nil {
-		records = append(records, response.IpAccessControlLists...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSipIpAccessControlListResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListSipIpAccessControlListResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -244,18 +231,24 @@ func (c *ApiService) StreamSipIpAccessControlList(params *ListSipIpAccessControl
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010SipIpAccessControlList, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.IpAccessControlLists {
-				channel <- response.IpAccessControlLists[item]
+			responseRecords := response.IpAccessControlLists
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSipIpAccessControlListResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListSipIpAccessControlListResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_usage_records.go
+++ b/rest/api/v2010/accounts_usage_records.go
@@ -120,28 +120,15 @@ func (c *ApiService) PageUsageRecord(params *ListUsageRecordParams, pageToken, p
 
 // Lists UsageRecord records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUsageRecord(params *ListUsageRecordParams) ([]ApiV2010UsageRecord, error) {
-	if params == nil {
-		params = &ListUsageRecordParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageUsageRecord(params, "", "")
+	response, err := c.StreamUsageRecord(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010UsageRecord
+	records := make([]ApiV2010UsageRecord, 0)
 
-	for response != nil {
-		records = append(records, response.UsageRecords...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUsageRecordResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListUsageRecordResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -159,18 +146,24 @@ func (c *ApiService) StreamUsageRecord(params *ListUsageRecordParams) (chan ApiV
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010UsageRecord, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.UsageRecords {
-				channel <- response.UsageRecords[item]
+			responseRecords := response.UsageRecords
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUsageRecordResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListUsageRecordResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_usage_records_all_time.go
+++ b/rest/api/v2010/accounts_usage_records_all_time.go
@@ -120,28 +120,15 @@ func (c *ApiService) PageUsageRecordAllTime(params *ListUsageRecordAllTimeParams
 
 // Lists UsageRecordAllTime records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUsageRecordAllTime(params *ListUsageRecordAllTimeParams) ([]ApiV2010UsageRecordAllTime, error) {
-	if params == nil {
-		params = &ListUsageRecordAllTimeParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageUsageRecordAllTime(params, "", "")
+	response, err := c.StreamUsageRecordAllTime(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010UsageRecordAllTime
+	records := make([]ApiV2010UsageRecordAllTime, 0)
 
-	for response != nil {
-		records = append(records, response.UsageRecords...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUsageRecordAllTimeResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListUsageRecordAllTimeResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -159,18 +146,24 @@ func (c *ApiService) StreamUsageRecordAllTime(params *ListUsageRecordAllTimePara
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010UsageRecordAllTime, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.UsageRecords {
-				channel <- response.UsageRecords[item]
+			responseRecords := response.UsageRecords
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUsageRecordAllTimeResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListUsageRecordAllTimeResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_usage_records_last_month.go
+++ b/rest/api/v2010/accounts_usage_records_last_month.go
@@ -120,28 +120,15 @@ func (c *ApiService) PageUsageRecordLastMonth(params *ListUsageRecordLastMonthPa
 
 // Lists UsageRecordLastMonth records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUsageRecordLastMonth(params *ListUsageRecordLastMonthParams) ([]ApiV2010UsageRecordLastMonth, error) {
-	if params == nil {
-		params = &ListUsageRecordLastMonthParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageUsageRecordLastMonth(params, "", "")
+	response, err := c.StreamUsageRecordLastMonth(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010UsageRecordLastMonth
+	records := make([]ApiV2010UsageRecordLastMonth, 0)
 
-	for response != nil {
-		records = append(records, response.UsageRecords...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUsageRecordLastMonthResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListUsageRecordLastMonthResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -159,18 +146,24 @@ func (c *ApiService) StreamUsageRecordLastMonth(params *ListUsageRecordLastMonth
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010UsageRecordLastMonth, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.UsageRecords {
-				channel <- response.UsageRecords[item]
+			responseRecords := response.UsageRecords
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUsageRecordLastMonthResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListUsageRecordLastMonthResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_usage_records_monthly.go
+++ b/rest/api/v2010/accounts_usage_records_monthly.go
@@ -120,28 +120,15 @@ func (c *ApiService) PageUsageRecordMonthly(params *ListUsageRecordMonthlyParams
 
 // Lists UsageRecordMonthly records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUsageRecordMonthly(params *ListUsageRecordMonthlyParams) ([]ApiV2010UsageRecordMonthly, error) {
-	if params == nil {
-		params = &ListUsageRecordMonthlyParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageUsageRecordMonthly(params, "", "")
+	response, err := c.StreamUsageRecordMonthly(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010UsageRecordMonthly
+	records := make([]ApiV2010UsageRecordMonthly, 0)
 
-	for response != nil {
-		records = append(records, response.UsageRecords...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUsageRecordMonthlyResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListUsageRecordMonthlyResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -159,18 +146,24 @@ func (c *ApiService) StreamUsageRecordMonthly(params *ListUsageRecordMonthlyPara
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010UsageRecordMonthly, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.UsageRecords {
-				channel <- response.UsageRecords[item]
+			responseRecords := response.UsageRecords
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUsageRecordMonthlyResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListUsageRecordMonthlyResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_usage_records_this_month.go
+++ b/rest/api/v2010/accounts_usage_records_this_month.go
@@ -120,28 +120,15 @@ func (c *ApiService) PageUsageRecordThisMonth(params *ListUsageRecordThisMonthPa
 
 // Lists UsageRecordThisMonth records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUsageRecordThisMonth(params *ListUsageRecordThisMonthParams) ([]ApiV2010UsageRecordThisMonth, error) {
-	if params == nil {
-		params = &ListUsageRecordThisMonthParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageUsageRecordThisMonth(params, "", "")
+	response, err := c.StreamUsageRecordThisMonth(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010UsageRecordThisMonth
+	records := make([]ApiV2010UsageRecordThisMonth, 0)
 
-	for response != nil {
-		records = append(records, response.UsageRecords...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUsageRecordThisMonthResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListUsageRecordThisMonthResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -159,18 +146,24 @@ func (c *ApiService) StreamUsageRecordThisMonth(params *ListUsageRecordThisMonth
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010UsageRecordThisMonth, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.UsageRecords {
-				channel <- response.UsageRecords[item]
+			responseRecords := response.UsageRecords
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUsageRecordThisMonthResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListUsageRecordThisMonthResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_usage_records_today.go
+++ b/rest/api/v2010/accounts_usage_records_today.go
@@ -120,28 +120,15 @@ func (c *ApiService) PageUsageRecordToday(params *ListUsageRecordTodayParams, pa
 
 // Lists UsageRecordToday records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUsageRecordToday(params *ListUsageRecordTodayParams) ([]ApiV2010UsageRecordToday, error) {
-	if params == nil {
-		params = &ListUsageRecordTodayParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageUsageRecordToday(params, "", "")
+	response, err := c.StreamUsageRecordToday(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010UsageRecordToday
+	records := make([]ApiV2010UsageRecordToday, 0)
 
-	for response != nil {
-		records = append(records, response.UsageRecords...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUsageRecordTodayResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListUsageRecordTodayResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -159,18 +146,24 @@ func (c *ApiService) StreamUsageRecordToday(params *ListUsageRecordTodayParams) 
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010UsageRecordToday, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.UsageRecords {
-				channel <- response.UsageRecords[item]
+			responseRecords := response.UsageRecords
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUsageRecordTodayResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListUsageRecordTodayResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_usage_records_yesterday.go
+++ b/rest/api/v2010/accounts_usage_records_yesterday.go
@@ -120,28 +120,15 @@ func (c *ApiService) PageUsageRecordYesterday(params *ListUsageRecordYesterdayPa
 
 // Lists UsageRecordYesterday records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUsageRecordYesterday(params *ListUsageRecordYesterdayParams) ([]ApiV2010UsageRecordYesterday, error) {
-	if params == nil {
-		params = &ListUsageRecordYesterdayParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageUsageRecordYesterday(params, "", "")
+	response, err := c.StreamUsageRecordYesterday(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010UsageRecordYesterday
+	records := make([]ApiV2010UsageRecordYesterday, 0)
 
-	for response != nil {
-		records = append(records, response.UsageRecords...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUsageRecordYesterdayResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListUsageRecordYesterdayResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -159,18 +146,24 @@ func (c *ApiService) StreamUsageRecordYesterday(params *ListUsageRecordYesterday
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010UsageRecordYesterday, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.UsageRecords {
-				channel <- response.UsageRecords[item]
+			responseRecords := response.UsageRecords
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUsageRecordYesterdayResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListUsageRecordYesterdayResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/api/v2010/accounts_usage_triggers.go
+++ b/rest/api/v2010/accounts_usage_triggers.go
@@ -285,28 +285,15 @@ func (c *ApiService) PageUsageTrigger(params *ListUsageTriggerParams, pageToken,
 
 // Lists UsageTrigger records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUsageTrigger(params *ListUsageTriggerParams) ([]ApiV2010UsageTrigger, error) {
-	if params == nil {
-		params = &ListUsageTriggerParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageUsageTrigger(params, "", "")
+	response, err := c.StreamUsageTrigger(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ApiV2010UsageTrigger
+	records := make([]ApiV2010UsageTrigger, 0)
 
-	for response != nil {
-		records = append(records, response.UsageTriggers...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUsageTriggerResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListUsageTriggerResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -324,18 +311,24 @@ func (c *ApiService) StreamUsageTrigger(params *ListUsageTriggerParams) (chan Ap
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ApiV2010UsageTrigger, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.UsageTriggers {
-				channel <- response.UsageTriggers[item]
+			responseRecords := response.UsageTriggers
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUsageTriggerResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListUsageTriggerResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/autopilot/v1/assistants_field_types.go
+++ b/rest/autopilot/v1/assistants_field_types.go
@@ -161,28 +161,15 @@ func (c *ApiService) PageFieldType(AssistantSid string, params *ListFieldTypePar
 
 // Lists FieldType records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListFieldType(AssistantSid string, params *ListFieldTypeParams) ([]AutopilotV1FieldType, error) {
-	if params == nil {
-		params = &ListFieldTypeParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageFieldType(AssistantSid, params, "", "")
+	response, err := c.StreamFieldType(AssistantSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []AutopilotV1FieldType
+	records := make([]AutopilotV1FieldType, 0)
 
-	for response != nil {
-		records = append(records, response.FieldTypes...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListFieldTypeResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListFieldTypeResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -200,18 +187,24 @@ func (c *ApiService) StreamFieldType(AssistantSid string, params *ListFieldTypeP
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan AutopilotV1FieldType, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.FieldTypes {
-				channel <- response.FieldTypes[item]
+			responseRecords := response.FieldTypes
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListFieldTypeResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListFieldTypeResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/autopilot/v1/assistants_queries.go
+++ b/rest/autopilot/v1/assistants_queries.go
@@ -215,28 +215,15 @@ func (c *ApiService) PageQuery(AssistantSid string, params *ListQueryParams, pag
 
 // Lists Query records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListQuery(AssistantSid string, params *ListQueryParams) ([]AutopilotV1Query, error) {
-	if params == nil {
-		params = &ListQueryParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageQuery(AssistantSid, params, "", "")
+	response, err := c.StreamQuery(AssistantSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []AutopilotV1Query
+	records := make([]AutopilotV1Query, 0)
 
-	for response != nil {
-		records = append(records, response.Queries...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListQueryResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListQueryResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -254,18 +241,24 @@ func (c *ApiService) StreamQuery(AssistantSid string, params *ListQueryParams) (
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan AutopilotV1Query, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Queries {
-				channel <- response.Queries[item]
+			responseRecords := response.Queries
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListQueryResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListQueryResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/autopilot/v1/assistants_tasks.go
+++ b/rest/autopilot/v1/assistants_tasks.go
@@ -185,28 +185,15 @@ func (c *ApiService) PageTask(AssistantSid string, params *ListTaskParams, pageT
 
 // Lists Task records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListTask(AssistantSid string, params *ListTaskParams) ([]AutopilotV1Task, error) {
-	if params == nil {
-		params = &ListTaskParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageTask(AssistantSid, params, "", "")
+	response, err := c.StreamTask(AssistantSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []AutopilotV1Task
+	records := make([]AutopilotV1Task, 0)
 
-	for response != nil {
-		records = append(records, response.Tasks...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListTaskResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListTaskResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -224,18 +211,24 @@ func (c *ApiService) StreamTask(AssistantSid string, params *ListTaskParams) (ch
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan AutopilotV1Task, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Tasks {
-				channel <- response.Tasks[item]
+			responseRecords := response.Tasks
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListTaskResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListTaskResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/autopilot/v1/assistants_webhooks.go
+++ b/rest/autopilot/v1/assistants_webhooks.go
@@ -179,28 +179,15 @@ func (c *ApiService) PageWebhook(AssistantSid string, params *ListWebhookParams,
 
 // Lists Webhook records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListWebhook(AssistantSid string, params *ListWebhookParams) ([]AutopilotV1Webhook, error) {
-	if params == nil {
-		params = &ListWebhookParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageWebhook(AssistantSid, params, "", "")
+	response, err := c.StreamWebhook(AssistantSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []AutopilotV1Webhook
+	records := make([]AutopilotV1Webhook, 0)
 
-	for response != nil {
-		records = append(records, response.Webhooks...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListWebhookResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListWebhookResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -218,18 +205,24 @@ func (c *ApiService) StreamWebhook(AssistantSid string, params *ListWebhookParam
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan AutopilotV1Webhook, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Webhooks {
-				channel <- response.Webhooks[item]
+			responseRecords := response.Webhooks
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListWebhookResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListWebhookResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/chat/v1/credentials.go
+++ b/rest/chat/v1/credentials.go
@@ -201,28 +201,15 @@ func (c *ApiService) PageCredential(params *ListCredentialParams, pageToken, pag
 
 // Lists Credential records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCredential(params *ListCredentialParams) ([]ChatV1Credential, error) {
-	if params == nil {
-		params = &ListCredentialParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageCredential(params, "", "")
+	response, err := c.StreamCredential(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ChatV1Credential
+	records := make([]ChatV1Credential, 0)
 
-	for response != nil {
-		records = append(records, response.Credentials...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCredentialResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListCredentialResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -240,18 +227,24 @@ func (c *ApiService) StreamCredential(params *ListCredentialParams) (chan ChatV1
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ChatV1Credential, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Credentials {
-				channel <- response.Credentials[item]
+			responseRecords := response.Credentials
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCredentialResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListCredentialResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/chat/v1/services.go
+++ b/rest/chat/v1/services.go
@@ -147,28 +147,15 @@ func (c *ApiService) PageService(params *ListServiceParams, pageToken, pageNumbe
 
 // Lists Service records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListService(params *ListServiceParams) ([]ChatV1Service, error) {
-	if params == nil {
-		params = &ListServiceParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageService(params, "", "")
+	response, err := c.StreamService(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ChatV1Service
+	records := make([]ChatV1Service, 0)
 
-	for response != nil {
-		records = append(records, response.Services...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListServiceResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -186,18 +173,24 @@ func (c *ApiService) StreamService(params *ListServiceParams) (chan ChatV1Servic
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ChatV1Service, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Services {
-				channel <- response.Services[item]
+			responseRecords := response.Services
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/chat/v1/services_channels.go
+++ b/rest/chat/v1/services_channels.go
@@ -190,28 +190,15 @@ func (c *ApiService) PageChannel(ServiceSid string, params *ListChannelParams, p
 
 // Lists Channel records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListChannel(ServiceSid string, params *ListChannelParams) ([]ChatV1Channel, error) {
-	if params == nil {
-		params = &ListChannelParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageChannel(ServiceSid, params, "", "")
+	response, err := c.StreamChannel(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ChatV1Channel
+	records := make([]ChatV1Channel, 0)
 
-	for response != nil {
-		records = append(records, response.Channels...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListChannelResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListChannelResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -229,18 +216,24 @@ func (c *ApiService) StreamChannel(ServiceSid string, params *ListChannelParams)
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ChatV1Channel, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Channels {
-				channel <- response.Channels[item]
+			responseRecords := response.Channels
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListChannelResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListChannelResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/chat/v1/services_channels_invites.go
+++ b/rest/chat/v1/services_channels_invites.go
@@ -176,28 +176,15 @@ func (c *ApiService) PageInvite(ServiceSid string, ChannelSid string, params *Li
 
 // Lists Invite records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListInvite(ServiceSid string, ChannelSid string, params *ListInviteParams) ([]ChatV1Invite, error) {
-	if params == nil {
-		params = &ListInviteParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageInvite(ServiceSid, ChannelSid, params, "", "")
+	response, err := c.StreamInvite(ServiceSid, ChannelSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ChatV1Invite
+	records := make([]ChatV1Invite, 0)
 
-	for response != nil {
-		records = append(records, response.Invites...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListInviteResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListInviteResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -215,18 +202,24 @@ func (c *ApiService) StreamInvite(ServiceSid string, ChannelSid string, params *
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ChatV1Invite, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Invites {
-				channel <- response.Invites[item]
+			responseRecords := response.Invites
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListInviteResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListInviteResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/chat/v1/services_channels_members.go
+++ b/rest/chat/v1/services_channels_members.go
@@ -176,28 +176,15 @@ func (c *ApiService) PageMember(ServiceSid string, ChannelSid string, params *Li
 
 // Lists Member records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMember(ServiceSid string, ChannelSid string, params *ListMemberParams) ([]ChatV1Member, error) {
-	if params == nil {
-		params = &ListMemberParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageMember(ServiceSid, ChannelSid, params, "", "")
+	response, err := c.StreamMember(ServiceSid, ChannelSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ChatV1Member
+	records := make([]ChatV1Member, 0)
 
-	for response != nil {
-		records = append(records, response.Members...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListMemberResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListMemberResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -215,18 +202,24 @@ func (c *ApiService) StreamMember(ServiceSid string, ChannelSid string, params *
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ChatV1Member, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Members {
-				channel <- response.Members[item]
+			responseRecords := response.Members
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListMemberResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListMemberResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/chat/v1/services_channels_messages.go
+++ b/rest/chat/v1/services_channels_messages.go
@@ -183,28 +183,15 @@ func (c *ApiService) PageMessage(ServiceSid string, ChannelSid string, params *L
 
 // Lists Message records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMessage(ServiceSid string, ChannelSid string, params *ListMessageParams) ([]ChatV1Message, error) {
-	if params == nil {
-		params = &ListMessageParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageMessage(ServiceSid, ChannelSid, params, "", "")
+	response, err := c.StreamMessage(ServiceSid, ChannelSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ChatV1Message
+	records := make([]ChatV1Message, 0)
 
-	for response != nil {
-		records = append(records, response.Messages...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListMessageResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListMessageResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -222,18 +209,24 @@ func (c *ApiService) StreamMessage(ServiceSid string, ChannelSid string, params 
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ChatV1Message, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Messages {
-				channel <- response.Messages[item]
+			responseRecords := response.Messages
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListMessageResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListMessageResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/chat/v1/services_roles.go
+++ b/rest/chat/v1/services_roles.go
@@ -172,28 +172,15 @@ func (c *ApiService) PageRole(ServiceSid string, params *ListRoleParams, pageTok
 
 // Lists Role records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRole(ServiceSid string, params *ListRoleParams) ([]ChatV1Role, error) {
-	if params == nil {
-		params = &ListRoleParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageRole(ServiceSid, params, "", "")
+	response, err := c.StreamRole(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ChatV1Role
+	records := make([]ChatV1Role, 0)
 
-	for response != nil {
-		records = append(records, response.Roles...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRoleResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListRoleResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -211,18 +198,24 @@ func (c *ApiService) StreamRole(ServiceSid string, params *ListRoleParams) (chan
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ChatV1Role, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Roles {
-				channel <- response.Roles[item]
+			responseRecords := response.Roles
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRoleResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListRoleResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/chat/v1/services_users.go
+++ b/rest/chat/v1/services_users.go
@@ -179,28 +179,15 @@ func (c *ApiService) PageUser(ServiceSid string, params *ListUserParams, pageTok
 
 // Lists User records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUser(ServiceSid string, params *ListUserParams) ([]ChatV1User, error) {
-	if params == nil {
-		params = &ListUserParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageUser(ServiceSid, params, "", "")
+	response, err := c.StreamUser(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ChatV1User
+	records := make([]ChatV1User, 0)
 
-	for response != nil {
-		records = append(records, response.Users...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUserResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListUserResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -218,18 +205,24 @@ func (c *ApiService) StreamUser(ServiceSid string, params *ListUserParams) (chan
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ChatV1User, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Users {
-				channel <- response.Users[item]
+			responseRecords := response.Users
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUserResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListUserResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/chat/v1/services_users_channels.go
+++ b/rest/chat/v1/services_users_channels.go
@@ -75,28 +75,15 @@ func (c *ApiService) PageUserChannel(ServiceSid string, UserSid string, params *
 
 // Lists UserChannel records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUserChannel(ServiceSid string, UserSid string, params *ListUserChannelParams) ([]ChatV1UserChannel, error) {
-	if params == nil {
-		params = &ListUserChannelParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageUserChannel(ServiceSid, UserSid, params, "", "")
+	response, err := c.StreamUserChannel(ServiceSid, UserSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ChatV1UserChannel
+	records := make([]ChatV1UserChannel, 0)
 
-	for response != nil {
-		records = append(records, response.Channels...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUserChannelResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListUserChannelResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -114,18 +101,24 @@ func (c *ApiService) StreamUserChannel(ServiceSid string, UserSid string, params
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ChatV1UserChannel, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Channels {
-				channel <- response.Channels[item]
+			responseRecords := response.Channels
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUserChannelResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListUserChannelResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/chat/v2/services.go
+++ b/rest/chat/v2/services.go
@@ -147,28 +147,15 @@ func (c *ApiService) PageService(params *ListServiceParams, pageToken, pageNumbe
 
 // Lists Service records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListService(params *ListServiceParams) ([]ChatV2Service, error) {
-	if params == nil {
-		params = &ListServiceParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageService(params, "", "")
+	response, err := c.StreamService(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ChatV2Service
+	records := make([]ChatV2Service, 0)
 
-	for response != nil {
-		records = append(records, response.Services...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListServiceResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -186,18 +173,24 @@ func (c *ApiService) StreamService(params *ListServiceParams) (chan ChatV2Servic
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ChatV2Service, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Services {
-				channel <- response.Services[item]
+			responseRecords := response.Services
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/chat/v2/services_bindings.go
+++ b/rest/chat/v2/services_bindings.go
@@ -137,28 +137,15 @@ func (c *ApiService) PageBinding(ServiceSid string, params *ListBindingParams, p
 
 // Lists Binding records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListBinding(ServiceSid string, params *ListBindingParams) ([]ChatV2Binding, error) {
-	if params == nil {
-		params = &ListBindingParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageBinding(ServiceSid, params, "", "")
+	response, err := c.StreamBinding(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ChatV2Binding
+	records := make([]ChatV2Binding, 0)
 
-	for response != nil {
-		records = append(records, response.Bindings...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListBindingResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListBindingResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -176,18 +163,24 @@ func (c *ApiService) StreamBinding(ServiceSid string, params *ListBindingParams)
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ChatV2Binding, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Bindings {
-				channel <- response.Bindings[item]
+			responseRecords := response.Bindings
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListBindingResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListBindingResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/chat/v2/services_channels_invites.go
+++ b/rest/chat/v2/services_channels_invites.go
@@ -176,28 +176,15 @@ func (c *ApiService) PageInvite(ServiceSid string, ChannelSid string, params *Li
 
 // Lists Invite records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListInvite(ServiceSid string, ChannelSid string, params *ListInviteParams) ([]ChatV2Invite, error) {
-	if params == nil {
-		params = &ListInviteParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageInvite(ServiceSid, ChannelSid, params, "", "")
+	response, err := c.StreamInvite(ServiceSid, ChannelSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ChatV2Invite
+	records := make([]ChatV2Invite, 0)
 
-	for response != nil {
-		records = append(records, response.Invites...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListInviteResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListInviteResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -215,18 +202,24 @@ func (c *ApiService) StreamInvite(ServiceSid string, ChannelSid string, params *
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ChatV2Invite, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Invites {
-				channel <- response.Invites[item]
+			responseRecords := response.Invites
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListInviteResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListInviteResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/chat/v2/services_channels_members.go
+++ b/rest/chat/v2/services_channels_members.go
@@ -247,28 +247,15 @@ func (c *ApiService) PageMember(ServiceSid string, ChannelSid string, params *Li
 
 // Lists Member records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMember(ServiceSid string, ChannelSid string, params *ListMemberParams) ([]ChatV2Member, error) {
-	if params == nil {
-		params = &ListMemberParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageMember(ServiceSid, ChannelSid, params, "", "")
+	response, err := c.StreamMember(ServiceSid, ChannelSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ChatV2Member
+	records := make([]ChatV2Member, 0)
 
-	for response != nil {
-		records = append(records, response.Members...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListMemberResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListMemberResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -286,18 +273,24 @@ func (c *ApiService) StreamMember(ServiceSid string, ChannelSid string, params *
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ChatV2Member, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Members {
-				channel <- response.Members[item]
+			responseRecords := response.Members
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListMemberResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListMemberResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/chat/v2/services_channels_messages.go
+++ b/rest/chat/v2/services_channels_messages.go
@@ -245,28 +245,15 @@ func (c *ApiService) PageMessage(ServiceSid string, ChannelSid string, params *L
 
 // Lists Message records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMessage(ServiceSid string, ChannelSid string, params *ListMessageParams) ([]ChatV2Message, error) {
-	if params == nil {
-		params = &ListMessageParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageMessage(ServiceSid, ChannelSid, params, "", "")
+	response, err := c.StreamMessage(ServiceSid, ChannelSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ChatV2Message
+	records := make([]ChatV2Message, 0)
 
-	for response != nil {
-		records = append(records, response.Messages...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListMessageResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListMessageResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -284,18 +271,24 @@ func (c *ApiService) StreamMessage(ServiceSid string, ChannelSid string, params 
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ChatV2Message, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Messages {
-				channel <- response.Messages[item]
+			responseRecords := response.Messages
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListMessageResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListMessageResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/chat/v2/services_channels_webhooks.go
+++ b/rest/chat/v2/services_channels_webhooks.go
@@ -214,28 +214,15 @@ func (c *ApiService) PageChannelWebhook(ServiceSid string, ChannelSid string, pa
 
 // Lists ChannelWebhook records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListChannelWebhook(ServiceSid string, ChannelSid string, params *ListChannelWebhookParams) ([]ChatV2ChannelWebhook, error) {
-	if params == nil {
-		params = &ListChannelWebhookParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageChannelWebhook(ServiceSid, ChannelSid, params, "", "")
+	response, err := c.StreamChannelWebhook(ServiceSid, ChannelSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ChatV2ChannelWebhook
+	records := make([]ChatV2ChannelWebhook, 0)
 
-	for response != nil {
-		records = append(records, response.Webhooks...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListChannelWebhookResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListChannelWebhookResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -253,18 +240,24 @@ func (c *ApiService) StreamChannelWebhook(ServiceSid string, ChannelSid string, 
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ChatV2ChannelWebhook, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Webhooks {
-				channel <- response.Webhooks[item]
+			responseRecords := response.Webhooks
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListChannelWebhookResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListChannelWebhookResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/chat/v2/services_roles.go
+++ b/rest/chat/v2/services_roles.go
@@ -172,28 +172,15 @@ func (c *ApiService) PageRole(ServiceSid string, params *ListRoleParams, pageTok
 
 // Lists Role records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRole(ServiceSid string, params *ListRoleParams) ([]ChatV2Role, error) {
-	if params == nil {
-		params = &ListRoleParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageRole(ServiceSid, params, "", "")
+	response, err := c.StreamRole(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ChatV2Role
+	records := make([]ChatV2Role, 0)
 
-	for response != nil {
-		records = append(records, response.Roles...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRoleResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListRoleResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -211,18 +198,24 @@ func (c *ApiService) StreamRole(ServiceSid string, params *ListRoleParams) (chan
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ChatV2Role, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Roles {
-				channel <- response.Roles[item]
+			responseRecords := response.Roles
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRoleResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListRoleResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/chat/v2/services_users.go
+++ b/rest/chat/v2/services_users.go
@@ -189,28 +189,15 @@ func (c *ApiService) PageUser(ServiceSid string, params *ListUserParams, pageTok
 
 // Lists User records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUser(ServiceSid string, params *ListUserParams) ([]ChatV2User, error) {
-	if params == nil {
-		params = &ListUserParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageUser(ServiceSid, params, "", "")
+	response, err := c.StreamUser(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ChatV2User
+	records := make([]ChatV2User, 0)
 
-	for response != nil {
-		records = append(records, response.Users...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUserResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListUserResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -228,18 +215,24 @@ func (c *ApiService) StreamUser(ServiceSid string, params *ListUserParams) (chan
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ChatV2User, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Users {
-				channel <- response.Users[item]
+			responseRecords := response.Users
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUserResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListUserResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/chat/v2/services_users_bindings.go
+++ b/rest/chat/v2/services_users_bindings.go
@@ -129,28 +129,15 @@ func (c *ApiService) PageUserBinding(ServiceSid string, UserSid string, params *
 
 // Lists UserBinding records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUserBinding(ServiceSid string, UserSid string, params *ListUserBindingParams) ([]ChatV2UserBinding, error) {
-	if params == nil {
-		params = &ListUserBindingParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageUserBinding(ServiceSid, UserSid, params, "", "")
+	response, err := c.StreamUserBinding(ServiceSid, UserSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ChatV2UserBinding
+	records := make([]ChatV2UserBinding, 0)
 
-	for response != nil {
-		records = append(records, response.Bindings...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUserBindingResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListUserBindingResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -168,18 +155,24 @@ func (c *ApiService) StreamUserBinding(ServiceSid string, UserSid string, params
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ChatV2UserBinding, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Bindings {
-				channel <- response.Bindings[item]
+			responseRecords := response.Bindings
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUserBindingResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListUserBindingResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/chat/v2/services_users_channels.go
+++ b/rest/chat/v2/services_users_channels.go
@@ -135,28 +135,15 @@ func (c *ApiService) PageUserChannel(ServiceSid string, UserSid string, params *
 
 // Lists UserChannel records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUserChannel(ServiceSid string, UserSid string, params *ListUserChannelParams) ([]ChatV2UserChannel, error) {
-	if params == nil {
-		params = &ListUserChannelParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageUserChannel(ServiceSid, UserSid, params, "", "")
+	response, err := c.StreamUserChannel(ServiceSid, UserSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ChatV2UserChannel
+	records := make([]ChatV2UserChannel, 0)
 
-	for response != nil {
-		records = append(records, response.Channels...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUserChannelResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListUserChannelResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -174,18 +161,24 @@ func (c *ApiService) StreamUserChannel(ServiceSid string, UserSid string, params
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ChatV2UserChannel, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Channels {
-				channel <- response.Channels[item]
+			responseRecords := response.Channels
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUserChannelResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListUserChannelResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/conversations/v1/credentials.go
+++ b/rest/conversations/v1/credentials.go
@@ -204,28 +204,15 @@ func (c *ApiService) PageCredential(params *ListCredentialParams, pageToken, pag
 
 // Lists Credential records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCredential(params *ListCredentialParams) ([]ConversationsV1Credential, error) {
-	if params == nil {
-		params = &ListCredentialParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageCredential(params, "", "")
+	response, err := c.StreamCredential(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ConversationsV1Credential
+	records := make([]ConversationsV1Credential, 0)
 
-	for response != nil {
-		records = append(records, response.Credentials...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCredentialResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListCredentialResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -243,18 +230,24 @@ func (c *ApiService) StreamCredential(params *ListCredentialParams) (chan Conver
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ConversationsV1Credential, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Credentials {
-				channel <- response.Credentials[item]
+			responseRecords := response.Credentials
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCredentialResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListCredentialResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/conversations/v1/services.go
+++ b/rest/conversations/v1/services.go
@@ -150,28 +150,15 @@ func (c *ApiService) PageService(params *ListServiceParams, pageToken, pageNumbe
 
 // Lists Service records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListService(params *ListServiceParams) ([]ConversationsV1Service, error) {
-	if params == nil {
-		params = &ListServiceParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageService(params, "", "")
+	response, err := c.StreamService(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ConversationsV1Service
+	records := make([]ConversationsV1Service, 0)
 
-	for response != nil {
-		records = append(records, response.Services...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListServiceResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -189,18 +176,24 @@ func (c *ApiService) StreamService(params *ListServiceParams) (chan Conversation
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ConversationsV1Service, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Services {
-				channel <- response.Services[item]
+			responseRecords := response.Services
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/conversations/v1/services_bindings.go
+++ b/rest/conversations/v1/services_bindings.go
@@ -139,28 +139,15 @@ func (c *ApiService) PageServiceBinding(ChatServiceSid string, params *ListServi
 
 // Lists ServiceBinding records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListServiceBinding(ChatServiceSid string, params *ListServiceBindingParams) ([]ConversationsV1ServiceBinding, error) {
-	if params == nil {
-		params = &ListServiceBindingParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageServiceBinding(ChatServiceSid, params, "", "")
+	response, err := c.StreamServiceBinding(ChatServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ConversationsV1ServiceBinding
+	records := make([]ConversationsV1ServiceBinding, 0)
 
-	for response != nil {
-		records = append(records, response.Bindings...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceBindingResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListServiceBindingResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -178,18 +165,24 @@ func (c *ApiService) StreamServiceBinding(ChatServiceSid string, params *ListSer
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ConversationsV1ServiceBinding, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Bindings {
-				channel <- response.Bindings[item]
+			responseRecords := response.Bindings
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceBindingResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceBindingResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/conversations/v1/services_conversations.go
+++ b/rest/conversations/v1/services_conversations.go
@@ -253,28 +253,15 @@ func (c *ApiService) PageServiceConversation(ChatServiceSid string, params *List
 
 // Lists ServiceConversation records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListServiceConversation(ChatServiceSid string, params *ListServiceConversationParams) ([]ConversationsV1ServiceConversation, error) {
-	if params == nil {
-		params = &ListServiceConversationParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageServiceConversation(ChatServiceSid, params, "", "")
+	response, err := c.StreamServiceConversation(ChatServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ConversationsV1ServiceConversation
+	records := make([]ConversationsV1ServiceConversation, 0)
 
-	for response != nil {
-		records = append(records, response.Conversations...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceConversationResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListServiceConversationResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -292,18 +279,24 @@ func (c *ApiService) StreamServiceConversation(ChatServiceSid string, params *Li
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ConversationsV1ServiceConversation, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Conversations {
-				channel <- response.Conversations[item]
+			responseRecords := response.Conversations
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceConversationResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceConversationResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/conversations/v1/services_conversations_messages.go
+++ b/rest/conversations/v1/services_conversations_messages.go
@@ -239,28 +239,15 @@ func (c *ApiService) PageServiceConversationMessage(ChatServiceSid string, Conve
 
 // Lists ServiceConversationMessage records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListServiceConversationMessage(ChatServiceSid string, ConversationSid string, params *ListServiceConversationMessageParams) ([]ConversationsV1ServiceConversationMessage, error) {
-	if params == nil {
-		params = &ListServiceConversationMessageParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageServiceConversationMessage(ChatServiceSid, ConversationSid, params, "", "")
+	response, err := c.StreamServiceConversationMessage(ChatServiceSid, ConversationSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ConversationsV1ServiceConversationMessage
+	records := make([]ConversationsV1ServiceConversationMessage, 0)
 
-	for response != nil {
-		records = append(records, response.Messages...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceConversationMessageResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListServiceConversationMessageResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -278,18 +265,24 @@ func (c *ApiService) StreamServiceConversationMessage(ChatServiceSid string, Con
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ConversationsV1ServiceConversationMessage, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Messages {
-				channel <- response.Messages[item]
+			responseRecords := response.Messages
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceConversationMessageResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceConversationMessageResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/conversations/v1/services_conversations_messages_receipts.go
+++ b/rest/conversations/v1/services_conversations_messages_receipts.go
@@ -102,28 +102,15 @@ func (c *ApiService) PageServiceConversationMessageReceipt(ChatServiceSid string
 
 // Lists ServiceConversationMessageReceipt records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListServiceConversationMessageReceipt(ChatServiceSid string, ConversationSid string, MessageSid string, params *ListServiceConversationMessageReceiptParams) ([]ConversationsV1ServiceConversationMessageReceipt, error) {
-	if params == nil {
-		params = &ListServiceConversationMessageReceiptParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageServiceConversationMessageReceipt(ChatServiceSid, ConversationSid, MessageSid, params, "", "")
+	response, err := c.StreamServiceConversationMessageReceipt(ChatServiceSid, ConversationSid, MessageSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ConversationsV1ServiceConversationMessageReceipt
+	records := make([]ConversationsV1ServiceConversationMessageReceipt, 0)
 
-	for response != nil {
-		records = append(records, response.DeliveryReceipts...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceConversationMessageReceiptResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListServiceConversationMessageReceiptResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -141,18 +128,24 @@ func (c *ApiService) StreamServiceConversationMessageReceipt(ChatServiceSid stri
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ConversationsV1ServiceConversationMessageReceipt, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.DeliveryReceipts {
-				channel <- response.DeliveryReceipts[item]
+			responseRecords := response.DeliveryReceipts
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceConversationMessageReceiptResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceConversationMessageReceiptResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/conversations/v1/services_conversations_participants.go
+++ b/rest/conversations/v1/services_conversations_participants.go
@@ -248,28 +248,15 @@ func (c *ApiService) PageServiceConversationParticipant(ChatServiceSid string, C
 
 // Lists ServiceConversationParticipant records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListServiceConversationParticipant(ChatServiceSid string, ConversationSid string, params *ListServiceConversationParticipantParams) ([]ConversationsV1ServiceConversationParticipant, error) {
-	if params == nil {
-		params = &ListServiceConversationParticipantParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageServiceConversationParticipant(ChatServiceSid, ConversationSid, params, "", "")
+	response, err := c.StreamServiceConversationParticipant(ChatServiceSid, ConversationSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ConversationsV1ServiceConversationParticipant
+	records := make([]ConversationsV1ServiceConversationParticipant, 0)
 
-	for response != nil {
-		records = append(records, response.Participants...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceConversationParticipantResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListServiceConversationParticipantResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -287,18 +274,24 @@ func (c *ApiService) StreamServiceConversationParticipant(ChatServiceSid string,
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ConversationsV1ServiceConversationParticipant, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Participants {
-				channel <- response.Participants[item]
+			responseRecords := response.Participants
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceConversationParticipantResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceConversationParticipantResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/conversations/v1/services_conversations_webhooks.go
+++ b/rest/conversations/v1/services_conversations_webhooks.go
@@ -217,28 +217,15 @@ func (c *ApiService) PageServiceConversationScopedWebhook(ChatServiceSid string,
 
 // Lists ServiceConversationScopedWebhook records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListServiceConversationScopedWebhook(ChatServiceSid string, ConversationSid string, params *ListServiceConversationScopedWebhookParams) ([]ConversationsV1ServiceConversationScopedWebhook, error) {
-	if params == nil {
-		params = &ListServiceConversationScopedWebhookParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageServiceConversationScopedWebhook(ChatServiceSid, ConversationSid, params, "", "")
+	response, err := c.StreamServiceConversationScopedWebhook(ChatServiceSid, ConversationSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ConversationsV1ServiceConversationScopedWebhook
+	records := make([]ConversationsV1ServiceConversationScopedWebhook, 0)
 
-	for response != nil {
-		records = append(records, response.Webhooks...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceConversationScopedWebhookResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListServiceConversationScopedWebhookResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -256,18 +243,24 @@ func (c *ApiService) StreamServiceConversationScopedWebhook(ChatServiceSid strin
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ConversationsV1ServiceConversationScopedWebhook, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Webhooks {
-				channel <- response.Webhooks[item]
+			responseRecords := response.Webhooks
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceConversationScopedWebhookResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceConversationScopedWebhookResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/conversations/v1/services_users.go
+++ b/rest/conversations/v1/services_users.go
@@ -207,28 +207,15 @@ func (c *ApiService) PageServiceUser(ChatServiceSid string, params *ListServiceU
 
 // Lists ServiceUser records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListServiceUser(ChatServiceSid string, params *ListServiceUserParams) ([]ConversationsV1ServiceUser, error) {
-	if params == nil {
-		params = &ListServiceUserParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageServiceUser(ChatServiceSid, params, "", "")
+	response, err := c.StreamServiceUser(ChatServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ConversationsV1ServiceUser
+	records := make([]ConversationsV1ServiceUser, 0)
 
-	for response != nil {
-		records = append(records, response.Users...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceUserResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListServiceUserResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -246,18 +233,24 @@ func (c *ApiService) StreamServiceUser(ChatServiceSid string, params *ListServic
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ConversationsV1ServiceUser, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Users {
-				channel <- response.Users[item]
+			responseRecords := response.Users
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceUserResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceUserResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/conversations/v1/services_users_conversations.go
+++ b/rest/conversations/v1/services_users_conversations.go
@@ -121,28 +121,15 @@ func (c *ApiService) PageServiceUserConversation(ChatServiceSid string, UserSid 
 
 // Lists ServiceUserConversation records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListServiceUserConversation(ChatServiceSid string, UserSid string, params *ListServiceUserConversationParams) ([]ConversationsV1ServiceUserConversation, error) {
-	if params == nil {
-		params = &ListServiceUserConversationParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageServiceUserConversation(ChatServiceSid, UserSid, params, "", "")
+	response, err := c.StreamServiceUserConversation(ChatServiceSid, UserSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ConversationsV1ServiceUserConversation
+	records := make([]ConversationsV1ServiceUserConversation, 0)
 
-	for response != nil {
-		records = append(records, response.Conversations...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceUserConversationResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListServiceUserConversationResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -160,18 +147,24 @@ func (c *ApiService) StreamServiceUserConversation(ChatServiceSid string, UserSi
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ConversationsV1ServiceUserConversation, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Conversations {
-				channel <- response.Conversations[item]
+			responseRecords := response.Conversations
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceUserConversationResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceUserConversationResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/conversations/v1/users_conversations.go
+++ b/rest/conversations/v1/users_conversations.go
@@ -118,28 +118,15 @@ func (c *ApiService) PageUserConversation(UserSid string, params *ListUserConver
 
 // Lists UserConversation records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUserConversation(UserSid string, params *ListUserConversationParams) ([]ConversationsV1UserConversation, error) {
-	if params == nil {
-		params = &ListUserConversationParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageUserConversation(UserSid, params, "", "")
+	response, err := c.StreamUserConversation(UserSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ConversationsV1UserConversation
+	records := make([]ConversationsV1UserConversation, 0)
 
-	for response != nil {
-		records = append(records, response.Conversations...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUserConversationResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListUserConversationResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -157,18 +144,24 @@ func (c *ApiService) StreamUserConversation(UserSid string, params *ListUserConv
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ConversationsV1UserConversation, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Conversations {
-				channel <- response.Conversations[item]
+			responseRecords := response.Conversations
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUserConversationResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListUserConversationResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/events/v1/sinks.go
+++ b/rest/events/v1/sinks.go
@@ -192,28 +192,15 @@ func (c *ApiService) PageSink(params *ListSinkParams, pageToken, pageNumber stri
 
 // Lists Sink records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSink(params *ListSinkParams) ([]EventsV1Sink, error) {
-	if params == nil {
-		params = &ListSinkParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageSink(params, "", "")
+	response, err := c.StreamSink(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []EventsV1Sink
+	records := make([]EventsV1Sink, 0)
 
-	for response != nil {
-		records = append(records, response.Sinks...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSinkResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListSinkResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -231,18 +218,24 @@ func (c *ApiService) StreamSink(params *ListSinkParams) (chan EventsV1Sink, erro
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan EventsV1Sink, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Sinks {
-				channel <- response.Sinks[item]
+			responseRecords := response.Sinks
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSinkResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListSinkResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/events/v1/subscriptions.go
+++ b/rest/events/v1/subscriptions.go
@@ -185,28 +185,15 @@ func (c *ApiService) PageSubscription(params *ListSubscriptionParams, pageToken,
 
 // Lists Subscription records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSubscription(params *ListSubscriptionParams) ([]EventsV1Subscription, error) {
-	if params == nil {
-		params = &ListSubscriptionParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageSubscription(params, "", "")
+	response, err := c.StreamSubscription(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []EventsV1Subscription
+	records := make([]EventsV1Subscription, 0)
 
-	for response != nil {
-		records = append(records, response.Subscriptions...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSubscriptionResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListSubscriptionResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -224,18 +211,24 @@ func (c *ApiService) StreamSubscription(params *ListSubscriptionParams) (chan Ev
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan EventsV1Subscription, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Subscriptions {
-				channel <- response.Subscriptions[item]
+			responseRecords := response.Subscriptions
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSubscriptionResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListSubscriptionResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/fax/v1/faxes.go
+++ b/rest/fax/v1/faxes.go
@@ -150,28 +150,15 @@ func (c *ApiService) PageFax(params *ListFaxParams, pageToken, pageNumber string
 
 // Lists Fax records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListFax(params *ListFaxParams) ([]FaxV1Fax, error) {
-	if params == nil {
-		params = &ListFaxParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageFax(params, "", "")
+	response, err := c.StreamFax(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []FaxV1Fax
+	records := make([]FaxV1Fax, 0)
 
-	for response != nil {
-		records = append(records, response.Faxes...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListFaxResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListFaxResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -189,18 +176,24 @@ func (c *ApiService) StreamFax(params *ListFaxParams) (chan FaxV1Fax, error) {
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan FaxV1Fax, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Faxes {
-				channel <- response.Faxes[item]
+			responseRecords := response.Faxes
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListFaxResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListFaxResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/flex/v1/channels.go
+++ b/rest/flex/v1/channels.go
@@ -228,28 +228,15 @@ func (c *ApiService) PageChannel(params *ListChannelParams, pageToken, pageNumbe
 
 // Lists Channel records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListChannel(params *ListChannelParams) ([]FlexV1Channel, error) {
-	if params == nil {
-		params = &ListChannelParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageChannel(params, "", "")
+	response, err := c.StreamChannel(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []FlexV1Channel
+	records := make([]FlexV1Channel, 0)
 
-	for response != nil {
-		records = append(records, response.FlexChatChannels...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListChannelResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListChannelResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -267,18 +254,24 @@ func (c *ApiService) StreamChannel(params *ListChannelParams) (chan FlexV1Channe
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan FlexV1Channel, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.FlexChatChannels {
-				channel <- response.FlexChatChannels[item]
+			responseRecords := response.FlexChatChannels
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListChannelResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListChannelResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/flex/v1/flex_flows.go
+++ b/rest/flex/v1/flex_flows.go
@@ -300,28 +300,15 @@ func (c *ApiService) PageFlexFlow(params *ListFlexFlowParams, pageToken, pageNum
 
 // Lists FlexFlow records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListFlexFlow(params *ListFlexFlowParams) ([]FlexV1FlexFlow, error) {
-	if params == nil {
-		params = &ListFlexFlowParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageFlexFlow(params, "", "")
+	response, err := c.StreamFlexFlow(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []FlexV1FlexFlow
+	records := make([]FlexV1FlexFlow, 0)
 
-	for response != nil {
-		records = append(records, response.FlexFlows...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListFlexFlowResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListFlexFlowResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -339,18 +326,24 @@ func (c *ApiService) StreamFlexFlow(params *ListFlexFlowParams) (chan FlexV1Flex
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan FlexV1FlexFlow, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.FlexFlows {
-				channel <- response.FlexFlows[item]
+			responseRecords := response.FlexFlows
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListFlexFlowResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListFlexFlowResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/insights/v1/voice_events.go
+++ b/rest/insights/v1/voice_events.go
@@ -83,28 +83,15 @@ func (c *ApiService) PageEvent(CallSid string, params *ListEventParams, pageToke
 
 // Lists Event records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListEvent(CallSid string, params *ListEventParams) ([]InsightsV1Event, error) {
-	if params == nil {
-		params = &ListEventParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageEvent(CallSid, params, "", "")
+	response, err := c.StreamEvent(CallSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []InsightsV1Event
+	records := make([]InsightsV1Event, 0)
 
-	for response != nil {
-		records = append(records, response.Events...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListEventResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListEventResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -122,18 +109,24 @@ func (c *ApiService) StreamEvent(CallSid string, params *ListEventParams) (chan 
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan InsightsV1Event, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Events {
-				channel <- response.Events[item]
+			responseRecords := response.Events
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListEventResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListEventResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/ip_messaging/v1/credentials.go
+++ b/rest/ip_messaging/v1/credentials.go
@@ -201,28 +201,15 @@ func (c *ApiService) PageCredential(params *ListCredentialParams, pageToken, pag
 
 // Lists Credential records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCredential(params *ListCredentialParams) ([]IpMessagingV1Credential, error) {
-	if params == nil {
-		params = &ListCredentialParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageCredential(params, "", "")
+	response, err := c.StreamCredential(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []IpMessagingV1Credential
+	records := make([]IpMessagingV1Credential, 0)
 
-	for response != nil {
-		records = append(records, response.Credentials...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCredentialResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListCredentialResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -240,18 +227,24 @@ func (c *ApiService) StreamCredential(params *ListCredentialParams) (chan IpMess
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan IpMessagingV1Credential, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Credentials {
-				channel <- response.Credentials[item]
+			responseRecords := response.Credentials
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCredentialResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListCredentialResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/ip_messaging/v1/services.go
+++ b/rest/ip_messaging/v1/services.go
@@ -147,28 +147,15 @@ func (c *ApiService) PageService(params *ListServiceParams, pageToken, pageNumbe
 
 // Lists Service records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListService(params *ListServiceParams) ([]IpMessagingV1Service, error) {
-	if params == nil {
-		params = &ListServiceParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageService(params, "", "")
+	response, err := c.StreamService(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []IpMessagingV1Service
+	records := make([]IpMessagingV1Service, 0)
 
-	for response != nil {
-		records = append(records, response.Services...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListServiceResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -186,18 +173,24 @@ func (c *ApiService) StreamService(params *ListServiceParams) (chan IpMessagingV
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan IpMessagingV1Service, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Services {
-				channel <- response.Services[item]
+			responseRecords := response.Services
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/ip_messaging/v1/services_channels.go
+++ b/rest/ip_messaging/v1/services_channels.go
@@ -190,28 +190,15 @@ func (c *ApiService) PageChannel(ServiceSid string, params *ListChannelParams, p
 
 // Lists Channel records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListChannel(ServiceSid string, params *ListChannelParams) ([]IpMessagingV1Channel, error) {
-	if params == nil {
-		params = &ListChannelParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageChannel(ServiceSid, params, "", "")
+	response, err := c.StreamChannel(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []IpMessagingV1Channel
+	records := make([]IpMessagingV1Channel, 0)
 
-	for response != nil {
-		records = append(records, response.Channels...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListChannelResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListChannelResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -229,18 +216,24 @@ func (c *ApiService) StreamChannel(ServiceSid string, params *ListChannelParams)
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan IpMessagingV1Channel, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Channels {
-				channel <- response.Channels[item]
+			responseRecords := response.Channels
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListChannelResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListChannelResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/ip_messaging/v1/services_channels_invites.go
+++ b/rest/ip_messaging/v1/services_channels_invites.go
@@ -176,28 +176,15 @@ func (c *ApiService) PageInvite(ServiceSid string, ChannelSid string, params *Li
 
 // Lists Invite records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListInvite(ServiceSid string, ChannelSid string, params *ListInviteParams) ([]IpMessagingV1Invite, error) {
-	if params == nil {
-		params = &ListInviteParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageInvite(ServiceSid, ChannelSid, params, "", "")
+	response, err := c.StreamInvite(ServiceSid, ChannelSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []IpMessagingV1Invite
+	records := make([]IpMessagingV1Invite, 0)
 
-	for response != nil {
-		records = append(records, response.Invites...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListInviteResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListInviteResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -215,18 +202,24 @@ func (c *ApiService) StreamInvite(ServiceSid string, ChannelSid string, params *
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan IpMessagingV1Invite, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Invites {
-				channel <- response.Invites[item]
+			responseRecords := response.Invites
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListInviteResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListInviteResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/ip_messaging/v1/services_channels_members.go
+++ b/rest/ip_messaging/v1/services_channels_members.go
@@ -176,28 +176,15 @@ func (c *ApiService) PageMember(ServiceSid string, ChannelSid string, params *Li
 
 // Lists Member records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMember(ServiceSid string, ChannelSid string, params *ListMemberParams) ([]IpMessagingV1Member, error) {
-	if params == nil {
-		params = &ListMemberParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageMember(ServiceSid, ChannelSid, params, "", "")
+	response, err := c.StreamMember(ServiceSid, ChannelSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []IpMessagingV1Member
+	records := make([]IpMessagingV1Member, 0)
 
-	for response != nil {
-		records = append(records, response.Members...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListMemberResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListMemberResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -215,18 +202,24 @@ func (c *ApiService) StreamMember(ServiceSid string, ChannelSid string, params *
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan IpMessagingV1Member, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Members {
-				channel <- response.Members[item]
+			responseRecords := response.Members
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListMemberResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListMemberResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/ip_messaging/v1/services_roles.go
+++ b/rest/ip_messaging/v1/services_roles.go
@@ -172,28 +172,15 @@ func (c *ApiService) PageRole(ServiceSid string, params *ListRoleParams, pageTok
 
 // Lists Role records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRole(ServiceSid string, params *ListRoleParams) ([]IpMessagingV1Role, error) {
-	if params == nil {
-		params = &ListRoleParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageRole(ServiceSid, params, "", "")
+	response, err := c.StreamRole(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []IpMessagingV1Role
+	records := make([]IpMessagingV1Role, 0)
 
-	for response != nil {
-		records = append(records, response.Roles...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRoleResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListRoleResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -211,18 +198,24 @@ func (c *ApiService) StreamRole(ServiceSid string, params *ListRoleParams) (chan
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan IpMessagingV1Role, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Roles {
-				channel <- response.Roles[item]
+			responseRecords := response.Roles
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRoleResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListRoleResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/ip_messaging/v1/services_users.go
+++ b/rest/ip_messaging/v1/services_users.go
@@ -179,28 +179,15 @@ func (c *ApiService) PageUser(ServiceSid string, params *ListUserParams, pageTok
 
 // Lists User records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUser(ServiceSid string, params *ListUserParams) ([]IpMessagingV1User, error) {
-	if params == nil {
-		params = &ListUserParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageUser(ServiceSid, params, "", "")
+	response, err := c.StreamUser(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []IpMessagingV1User
+	records := make([]IpMessagingV1User, 0)
 
-	for response != nil {
-		records = append(records, response.Users...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUserResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListUserResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -218,18 +205,24 @@ func (c *ApiService) StreamUser(ServiceSid string, params *ListUserParams) (chan
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan IpMessagingV1User, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Users {
-				channel <- response.Users[item]
+			responseRecords := response.Users
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUserResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListUserResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/ip_messaging/v1/services_users_channels.go
+++ b/rest/ip_messaging/v1/services_users_channels.go
@@ -75,28 +75,15 @@ func (c *ApiService) PageUserChannel(ServiceSid string, UserSid string, params *
 
 // Lists UserChannel records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUserChannel(ServiceSid string, UserSid string, params *ListUserChannelParams) ([]IpMessagingV1UserChannel, error) {
-	if params == nil {
-		params = &ListUserChannelParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageUserChannel(ServiceSid, UserSid, params, "", "")
+	response, err := c.StreamUserChannel(ServiceSid, UserSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []IpMessagingV1UserChannel
+	records := make([]IpMessagingV1UserChannel, 0)
 
-	for response != nil {
-		records = append(records, response.Channels...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUserChannelResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListUserChannelResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -114,18 +101,24 @@ func (c *ApiService) StreamUserChannel(ServiceSid string, UserSid string, params
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan IpMessagingV1UserChannel, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Channels {
-				channel <- response.Channels[item]
+			responseRecords := response.Channels
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUserChannelResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListUserChannelResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/ip_messaging/v2/credentials.go
+++ b/rest/ip_messaging/v2/credentials.go
@@ -201,28 +201,15 @@ func (c *ApiService) PageCredential(params *ListCredentialParams, pageToken, pag
 
 // Lists Credential records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCredential(params *ListCredentialParams) ([]IpMessagingV2Credential, error) {
-	if params == nil {
-		params = &ListCredentialParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageCredential(params, "", "")
+	response, err := c.StreamCredential(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []IpMessagingV2Credential
+	records := make([]IpMessagingV2Credential, 0)
 
-	for response != nil {
-		records = append(records, response.Credentials...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCredentialResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListCredentialResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -240,18 +227,24 @@ func (c *ApiService) StreamCredential(params *ListCredentialParams) (chan IpMess
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan IpMessagingV2Credential, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Credentials {
-				channel <- response.Credentials[item]
+			responseRecords := response.Credentials
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCredentialResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListCredentialResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/ip_messaging/v2/services.go
+++ b/rest/ip_messaging/v2/services.go
@@ -147,28 +147,15 @@ func (c *ApiService) PageService(params *ListServiceParams, pageToken, pageNumbe
 
 // Lists Service records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListService(params *ListServiceParams) ([]IpMessagingV2Service, error) {
-	if params == nil {
-		params = &ListServiceParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageService(params, "", "")
+	response, err := c.StreamService(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []IpMessagingV2Service
+	records := make([]IpMessagingV2Service, 0)
 
-	for response != nil {
-		records = append(records, response.Services...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListServiceResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -186,18 +173,24 @@ func (c *ApiService) StreamService(params *ListServiceParams) (chan IpMessagingV
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan IpMessagingV2Service, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Services {
-				channel <- response.Services[item]
+			responseRecords := response.Services
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/ip_messaging/v2/services_bindings.go
+++ b/rest/ip_messaging/v2/services_bindings.go
@@ -137,28 +137,15 @@ func (c *ApiService) PageBinding(ServiceSid string, params *ListBindingParams, p
 
 // Lists Binding records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListBinding(ServiceSid string, params *ListBindingParams) ([]IpMessagingV2Binding, error) {
-	if params == nil {
-		params = &ListBindingParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageBinding(ServiceSid, params, "", "")
+	response, err := c.StreamBinding(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []IpMessagingV2Binding
+	records := make([]IpMessagingV2Binding, 0)
 
-	for response != nil {
-		records = append(records, response.Bindings...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListBindingResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListBindingResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -176,18 +163,24 @@ func (c *ApiService) StreamBinding(ServiceSid string, params *ListBindingParams)
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan IpMessagingV2Binding, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Bindings {
-				channel <- response.Bindings[item]
+			responseRecords := response.Bindings
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListBindingResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListBindingResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/ip_messaging/v2/services_channels.go
+++ b/rest/ip_messaging/v2/services_channels.go
@@ -243,28 +243,15 @@ func (c *ApiService) PageChannel(ServiceSid string, params *ListChannelParams, p
 
 // Lists Channel records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListChannel(ServiceSid string, params *ListChannelParams) ([]IpMessagingV2Channel, error) {
-	if params == nil {
-		params = &ListChannelParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageChannel(ServiceSid, params, "", "")
+	response, err := c.StreamChannel(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []IpMessagingV2Channel
+	records := make([]IpMessagingV2Channel, 0)
 
-	for response != nil {
-		records = append(records, response.Channels...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListChannelResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListChannelResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -282,18 +269,24 @@ func (c *ApiService) StreamChannel(ServiceSid string, params *ListChannelParams)
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan IpMessagingV2Channel, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Channels {
-				channel <- response.Channels[item]
+			responseRecords := response.Channels
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListChannelResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListChannelResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/ip_messaging/v2/services_channels_invites.go
+++ b/rest/ip_messaging/v2/services_channels_invites.go
@@ -176,28 +176,15 @@ func (c *ApiService) PageInvite(ServiceSid string, ChannelSid string, params *Li
 
 // Lists Invite records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListInvite(ServiceSid string, ChannelSid string, params *ListInviteParams) ([]IpMessagingV2Invite, error) {
-	if params == nil {
-		params = &ListInviteParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageInvite(ServiceSid, ChannelSid, params, "", "")
+	response, err := c.StreamInvite(ServiceSid, ChannelSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []IpMessagingV2Invite
+	records := make([]IpMessagingV2Invite, 0)
 
-	for response != nil {
-		records = append(records, response.Invites...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListInviteResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListInviteResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -215,18 +202,24 @@ func (c *ApiService) StreamInvite(ServiceSid string, ChannelSid string, params *
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan IpMessagingV2Invite, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Invites {
-				channel <- response.Invites[item]
+			responseRecords := response.Invites
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListInviteResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListInviteResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/ip_messaging/v2/services_channels_members.go
+++ b/rest/ip_messaging/v2/services_channels_members.go
@@ -247,28 +247,15 @@ func (c *ApiService) PageMember(ServiceSid string, ChannelSid string, params *Li
 
 // Lists Member records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMember(ServiceSid string, ChannelSid string, params *ListMemberParams) ([]IpMessagingV2Member, error) {
-	if params == nil {
-		params = &ListMemberParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageMember(ServiceSid, ChannelSid, params, "", "")
+	response, err := c.StreamMember(ServiceSid, ChannelSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []IpMessagingV2Member
+	records := make([]IpMessagingV2Member, 0)
 
-	for response != nil {
-		records = append(records, response.Members...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListMemberResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListMemberResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -286,18 +273,24 @@ func (c *ApiService) StreamMember(ServiceSid string, ChannelSid string, params *
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan IpMessagingV2Member, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Members {
-				channel <- response.Members[item]
+			responseRecords := response.Members
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListMemberResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListMemberResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/ip_messaging/v2/services_channels_messages.go
+++ b/rest/ip_messaging/v2/services_channels_messages.go
@@ -245,28 +245,15 @@ func (c *ApiService) PageMessage(ServiceSid string, ChannelSid string, params *L
 
 // Lists Message records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMessage(ServiceSid string, ChannelSid string, params *ListMessageParams) ([]IpMessagingV2Message, error) {
-	if params == nil {
-		params = &ListMessageParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageMessage(ServiceSid, ChannelSid, params, "", "")
+	response, err := c.StreamMessage(ServiceSid, ChannelSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []IpMessagingV2Message
+	records := make([]IpMessagingV2Message, 0)
 
-	for response != nil {
-		records = append(records, response.Messages...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListMessageResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListMessageResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -284,18 +271,24 @@ func (c *ApiService) StreamMessage(ServiceSid string, ChannelSid string, params 
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan IpMessagingV2Message, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Messages {
-				channel <- response.Messages[item]
+			responseRecords := response.Messages
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListMessageResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListMessageResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/ip_messaging/v2/services_channels_webhooks.go
+++ b/rest/ip_messaging/v2/services_channels_webhooks.go
@@ -214,28 +214,15 @@ func (c *ApiService) PageChannelWebhook(ServiceSid string, ChannelSid string, pa
 
 // Lists ChannelWebhook records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListChannelWebhook(ServiceSid string, ChannelSid string, params *ListChannelWebhookParams) ([]IpMessagingV2ChannelWebhook, error) {
-	if params == nil {
-		params = &ListChannelWebhookParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageChannelWebhook(ServiceSid, ChannelSid, params, "", "")
+	response, err := c.StreamChannelWebhook(ServiceSid, ChannelSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []IpMessagingV2ChannelWebhook
+	records := make([]IpMessagingV2ChannelWebhook, 0)
 
-	for response != nil {
-		records = append(records, response.Webhooks...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListChannelWebhookResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListChannelWebhookResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -253,18 +240,24 @@ func (c *ApiService) StreamChannelWebhook(ServiceSid string, ChannelSid string, 
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan IpMessagingV2ChannelWebhook, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Webhooks {
-				channel <- response.Webhooks[item]
+			responseRecords := response.Webhooks
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListChannelWebhookResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListChannelWebhookResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/ip_messaging/v2/services_roles.go
+++ b/rest/ip_messaging/v2/services_roles.go
@@ -172,28 +172,15 @@ func (c *ApiService) PageRole(ServiceSid string, params *ListRoleParams, pageTok
 
 // Lists Role records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRole(ServiceSid string, params *ListRoleParams) ([]IpMessagingV2Role, error) {
-	if params == nil {
-		params = &ListRoleParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageRole(ServiceSid, params, "", "")
+	response, err := c.StreamRole(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []IpMessagingV2Role
+	records := make([]IpMessagingV2Role, 0)
 
-	for response != nil {
-		records = append(records, response.Roles...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRoleResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListRoleResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -211,18 +198,24 @@ func (c *ApiService) StreamRole(ServiceSid string, params *ListRoleParams) (chan
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan IpMessagingV2Role, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Roles {
-				channel <- response.Roles[item]
+			responseRecords := response.Roles
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRoleResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListRoleResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/ip_messaging/v2/services_users.go
+++ b/rest/ip_messaging/v2/services_users.go
@@ -189,28 +189,15 @@ func (c *ApiService) PageUser(ServiceSid string, params *ListUserParams, pageTok
 
 // Lists User records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUser(ServiceSid string, params *ListUserParams) ([]IpMessagingV2User, error) {
-	if params == nil {
-		params = &ListUserParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageUser(ServiceSid, params, "", "")
+	response, err := c.StreamUser(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []IpMessagingV2User
+	records := make([]IpMessagingV2User, 0)
 
-	for response != nil {
-		records = append(records, response.Users...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUserResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListUserResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -228,18 +215,24 @@ func (c *ApiService) StreamUser(ServiceSid string, params *ListUserParams) (chan
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan IpMessagingV2User, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Users {
-				channel <- response.Users[item]
+			responseRecords := response.Users
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUserResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListUserResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/ip_messaging/v2/services_users_bindings.go
+++ b/rest/ip_messaging/v2/services_users_bindings.go
@@ -129,28 +129,15 @@ func (c *ApiService) PageUserBinding(ServiceSid string, UserSid string, params *
 
 // Lists UserBinding records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUserBinding(ServiceSid string, UserSid string, params *ListUserBindingParams) ([]IpMessagingV2UserBinding, error) {
-	if params == nil {
-		params = &ListUserBindingParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageUserBinding(ServiceSid, UserSid, params, "", "")
+	response, err := c.StreamUserBinding(ServiceSid, UserSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []IpMessagingV2UserBinding
+	records := make([]IpMessagingV2UserBinding, 0)
 
-	for response != nil {
-		records = append(records, response.Bindings...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUserBindingResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListUserBindingResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -168,18 +155,24 @@ func (c *ApiService) StreamUserBinding(ServiceSid string, UserSid string, params
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan IpMessagingV2UserBinding, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Bindings {
-				channel <- response.Bindings[item]
+			responseRecords := response.Bindings
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUserBindingResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListUserBindingResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/ip_messaging/v2/services_users_channels.go
+++ b/rest/ip_messaging/v2/services_users_channels.go
@@ -119,28 +119,15 @@ func (c *ApiService) PageUserChannel(ServiceSid string, UserSid string, params *
 
 // Lists UserChannel records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUserChannel(ServiceSid string, UserSid string, params *ListUserChannelParams) ([]IpMessagingV2UserChannel, error) {
-	if params == nil {
-		params = &ListUserChannelParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageUserChannel(ServiceSid, UserSid, params, "", "")
+	response, err := c.StreamUserChannel(ServiceSid, UserSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []IpMessagingV2UserChannel
+	records := make([]IpMessagingV2UserChannel, 0)
 
-	for response != nil {
-		records = append(records, response.Channels...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUserChannelResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListUserChannelResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -158,18 +145,24 @@ func (c *ApiService) StreamUserChannel(ServiceSid string, UserSid string, params
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan IpMessagingV2UserChannel, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Channels {
-				channel <- response.Channels[item]
+			responseRecords := response.Channels
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUserChannelResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListUserChannelResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/media/v1/player_streamers.go
+++ b/rest/media/v1/player_streamers.go
@@ -167,28 +167,15 @@ func (c *ApiService) PagePlayerStreamer(params *ListPlayerStreamerParams, pageTo
 
 // Lists PlayerStreamer records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListPlayerStreamer(params *ListPlayerStreamerParams) ([]MediaV1PlayerStreamer, error) {
-	if params == nil {
-		params = &ListPlayerStreamerParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PagePlayerStreamer(params, "", "")
+	response, err := c.StreamPlayerStreamer(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []MediaV1PlayerStreamer
+	records := make([]MediaV1PlayerStreamer, 0)
 
-	for response != nil {
-		records = append(records, response.PlayerStreamers...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListPlayerStreamerResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListPlayerStreamerResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -206,18 +193,24 @@ func (c *ApiService) StreamPlayerStreamer(params *ListPlayerStreamerParams) (cha
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan MediaV1PlayerStreamer, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.PlayerStreamers {
-				channel <- response.PlayerStreamers[item]
+			responseRecords := response.PlayerStreamers
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListPlayerStreamerResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListPlayerStreamerResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/messaging/v1/a2p_brand_registrations.go
+++ b/rest/messaging/v1/a2p_brand_registrations.go
@@ -166,28 +166,15 @@ func (c *ApiService) PageBrandRegistrations(params *ListBrandRegistrationsParams
 
 // Lists BrandRegistrations records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListBrandRegistrations(params *ListBrandRegistrationsParams) ([]MessagingV1BrandRegistrations, error) {
-	if params == nil {
-		params = &ListBrandRegistrationsParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageBrandRegistrations(params, "", "")
+	response, err := c.StreamBrandRegistrations(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []MessagingV1BrandRegistrations
+	records := make([]MessagingV1BrandRegistrations, 0)
 
-	for response != nil {
-		records = append(records, response.Data...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListBrandRegistrationsResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListBrandRegistrationsResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -205,18 +192,24 @@ func (c *ApiService) StreamBrandRegistrations(params *ListBrandRegistrationsPara
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan MessagingV1BrandRegistrations, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Data {
-				channel <- response.Data[item]
+			responseRecords := response.Data
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListBrandRegistrationsResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListBrandRegistrationsResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/messaging/v1/services.go
+++ b/rest/messaging/v1/services.go
@@ -282,28 +282,15 @@ func (c *ApiService) PageService(params *ListServiceParams, pageToken, pageNumbe
 
 // Lists Service records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListService(params *ListServiceParams) ([]MessagingV1Service, error) {
-	if params == nil {
-		params = &ListServiceParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageService(params, "", "")
+	response, err := c.StreamService(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []MessagingV1Service
+	records := make([]MessagingV1Service, 0)
 
-	for response != nil {
-		records = append(records, response.Services...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListServiceResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -321,18 +308,24 @@ func (c *ApiService) StreamService(params *ListServiceParams) (chan MessagingV1S
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan MessagingV1Service, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Services {
-				channel <- response.Services[item]
+			responseRecords := response.Services
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/messaging/v1/services_phone_numbers.go
+++ b/rest/messaging/v1/services_phone_numbers.go
@@ -152,28 +152,15 @@ func (c *ApiService) PagePhoneNumber(ServiceSid string, params *ListPhoneNumberP
 
 // Lists PhoneNumber records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListPhoneNumber(ServiceSid string, params *ListPhoneNumberParams) ([]MessagingV1PhoneNumber, error) {
-	if params == nil {
-		params = &ListPhoneNumberParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PagePhoneNumber(ServiceSid, params, "", "")
+	response, err := c.StreamPhoneNumber(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []MessagingV1PhoneNumber
+	records := make([]MessagingV1PhoneNumber, 0)
 
-	for response != nil {
-		records = append(records, response.PhoneNumbers...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListPhoneNumberResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListPhoneNumberResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -191,18 +178,24 @@ func (c *ApiService) StreamPhoneNumber(ServiceSid string, params *ListPhoneNumbe
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan MessagingV1PhoneNumber, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.PhoneNumbers {
-				channel <- response.PhoneNumbers[item]
+			responseRecords := response.PhoneNumbers
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListPhoneNumberResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListPhoneNumberResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/messaging/v1/services_short_codes.go
+++ b/rest/messaging/v1/services_short_codes.go
@@ -152,28 +152,15 @@ func (c *ApiService) PageShortCode(ServiceSid string, params *ListShortCodeParam
 
 // Lists ShortCode records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListShortCode(ServiceSid string, params *ListShortCodeParams) ([]MessagingV1ShortCode, error) {
-	if params == nil {
-		params = &ListShortCodeParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageShortCode(ServiceSid, params, "", "")
+	response, err := c.StreamShortCode(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []MessagingV1ShortCode
+	records := make([]MessagingV1ShortCode, 0)
 
-	for response != nil {
-		records = append(records, response.ShortCodes...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListShortCodeResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListShortCodeResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -191,18 +178,24 @@ func (c *ApiService) StreamShortCode(ServiceSid string, params *ListShortCodePar
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan MessagingV1ShortCode, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.ShortCodes {
-				channel <- response.ShortCodes[item]
+			responseRecords := response.ShortCodes
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListShortCodeResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListShortCodeResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/monitor/v1/events.go
+++ b/rest/monitor/v1/events.go
@@ -149,28 +149,15 @@ func (c *ApiService) PageEvent(params *ListEventParams, pageToken, pageNumber st
 
 // Lists Event records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListEvent(params *ListEventParams) ([]MonitorV1Event, error) {
-	if params == nil {
-		params = &ListEventParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageEvent(params, "", "")
+	response, err := c.StreamEvent(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []MonitorV1Event
+	records := make([]MonitorV1Event, 0)
 
-	for response != nil {
-		records = append(records, response.Events...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListEventResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListEventResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -188,18 +175,24 @@ func (c *ApiService) StreamEvent(params *ListEventParams) (chan MonitorV1Event, 
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan MonitorV1Event, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Events {
-				channel <- response.Events[item]
+			responseRecords := response.Events
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListEventResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListEventResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/notify/v1/credentials.go
+++ b/rest/notify/v1/credentials.go
@@ -201,28 +201,15 @@ func (c *ApiService) PageCredential(params *ListCredentialParams, pageToken, pag
 
 // Lists Credential records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCredential(params *ListCredentialParams) ([]NotifyV1Credential, error) {
-	if params == nil {
-		params = &ListCredentialParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageCredential(params, "", "")
+	response, err := c.StreamCredential(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []NotifyV1Credential
+	records := make([]NotifyV1Credential, 0)
 
-	for response != nil {
-		records = append(records, response.Credentials...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCredentialResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListCredentialResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -240,18 +227,24 @@ func (c *ApiService) StreamCredential(params *ListCredentialParams) (chan Notify
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan NotifyV1Credential, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Credentials {
-				channel <- response.Credentials[item]
+			responseRecords := response.Credentials
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCredentialResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListCredentialResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/notify/v1/services.go
+++ b/rest/notify/v1/services.go
@@ -273,28 +273,15 @@ func (c *ApiService) PageService(params *ListServiceParams, pageToken, pageNumbe
 
 // Lists Service records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListService(params *ListServiceParams) ([]NotifyV1Service, error) {
-	if params == nil {
-		params = &ListServiceParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageService(params, "", "")
+	response, err := c.StreamService(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []NotifyV1Service
+	records := make([]NotifyV1Service, 0)
 
-	for response != nil {
-		records = append(records, response.Services...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListServiceResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -312,18 +299,24 @@ func (c *ApiService) StreamService(params *ListServiceParams) (chan NotifyV1Serv
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan NotifyV1Service, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Services {
-				channel <- response.Services[item]
+			responseRecords := response.Services
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/notify/v1/services_bindings.go
+++ b/rest/notify/v1/services_bindings.go
@@ -248,28 +248,15 @@ func (c *ApiService) PageBinding(ServiceSid string, params *ListBindingParams, p
 
 // Lists Binding records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListBinding(ServiceSid string, params *ListBindingParams) ([]NotifyV1Binding, error) {
-	if params == nil {
-		params = &ListBindingParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageBinding(ServiceSid, params, "", "")
+	response, err := c.StreamBinding(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []NotifyV1Binding
+	records := make([]NotifyV1Binding, 0)
 
-	for response != nil {
-		records = append(records, response.Bindings...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListBindingResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListBindingResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -287,18 +274,24 @@ func (c *ApiService) StreamBinding(ServiceSid string, params *ListBindingParams)
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan NotifyV1Binding, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Bindings {
-				channel <- response.Bindings[item]
+			responseRecords := response.Bindings
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListBindingResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListBindingResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/numbers/v2/regulatory_compliance_bundles.go
+++ b/rest/numbers/v2/regulatory_compliance_bundles.go
@@ -304,28 +304,15 @@ func (c *ApiService) PageBundle(params *ListBundleParams, pageToken, pageNumber 
 
 // Lists Bundle records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListBundle(params *ListBundleParams) ([]NumbersV2Bundle, error) {
-	if params == nil {
-		params = &ListBundleParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageBundle(params, "", "")
+	response, err := c.StreamBundle(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []NumbersV2Bundle
+	records := make([]NumbersV2Bundle, 0)
 
-	for response != nil {
-		records = append(records, response.Results...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListBundleResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListBundleResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -343,18 +330,24 @@ func (c *ApiService) StreamBundle(params *ListBundleParams) (chan NumbersV2Bundl
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan NumbersV2Bundle, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Results {
-				channel <- response.Results[item]
+			responseRecords := response.Results
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListBundleResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListBundleResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/numbers/v2/regulatory_compliance_bundles_evaluations.go
+++ b/rest/numbers/v2/regulatory_compliance_bundles_evaluations.go
@@ -121,28 +121,15 @@ func (c *ApiService) PageEvaluation(BundleSid string, params *ListEvaluationPara
 
 // Lists Evaluation records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListEvaluation(BundleSid string, params *ListEvaluationParams) ([]NumbersV2Evaluation, error) {
-	if params == nil {
-		params = &ListEvaluationParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageEvaluation(BundleSid, params, "", "")
+	response, err := c.StreamEvaluation(BundleSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []NumbersV2Evaluation
+	records := make([]NumbersV2Evaluation, 0)
 
-	for response != nil {
-		records = append(records, response.Results...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListEvaluationResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListEvaluationResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -160,18 +147,24 @@ func (c *ApiService) StreamEvaluation(BundleSid string, params *ListEvaluationPa
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan NumbersV2Evaluation, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Results {
-				channel <- response.Results[item]
+			responseRecords := response.Results
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListEvaluationResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListEvaluationResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/numbers/v2/regulatory_compliance_end_user_types.go
+++ b/rest/numbers/v2/regulatory_compliance_end_user_types.go
@@ -95,28 +95,15 @@ func (c *ApiService) PageEndUserType(params *ListEndUserTypeParams, pageToken, p
 
 // Lists EndUserType records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListEndUserType(params *ListEndUserTypeParams) ([]NumbersV2EndUserType, error) {
-	if params == nil {
-		params = &ListEndUserTypeParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageEndUserType(params, "", "")
+	response, err := c.StreamEndUserType(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []NumbersV2EndUserType
+	records := make([]NumbersV2EndUserType, 0)
 
-	for response != nil {
-		records = append(records, response.EndUserTypes...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListEndUserTypeResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListEndUserTypeResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -134,18 +121,24 @@ func (c *ApiService) StreamEndUserType(params *ListEndUserTypeParams) (chan Numb
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan NumbersV2EndUserType, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.EndUserTypes {
-				channel <- response.EndUserTypes[item]
+			responseRecords := response.EndUserTypes
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListEndUserTypeResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListEndUserTypeResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/numbers/v2/regulatory_compliance_end_users.go
+++ b/rest/numbers/v2/regulatory_compliance_end_users.go
@@ -174,28 +174,15 @@ func (c *ApiService) PageEndUser(params *ListEndUserParams, pageToken, pageNumbe
 
 // Lists EndUser records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListEndUser(params *ListEndUserParams) ([]NumbersV2EndUser, error) {
-	if params == nil {
-		params = &ListEndUserParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageEndUser(params, "", "")
+	response, err := c.StreamEndUser(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []NumbersV2EndUser
+	records := make([]NumbersV2EndUser, 0)
 
-	for response != nil {
-		records = append(records, response.Results...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListEndUserResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListEndUserResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -213,18 +200,24 @@ func (c *ApiService) StreamEndUser(params *ListEndUserParams) (chan NumbersV2End
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan NumbersV2EndUser, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Results {
-				channel <- response.Results[item]
+			responseRecords := response.Results
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListEndUserResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListEndUserResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/numbers/v2/regulatory_compliance_regulations.go
+++ b/rest/numbers/v2/regulatory_compliance_regulations.go
@@ -122,28 +122,15 @@ func (c *ApiService) PageRegulation(params *ListRegulationParams, pageToken, pag
 
 // Lists Regulation records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRegulation(params *ListRegulationParams) ([]NumbersV2Regulation, error) {
-	if params == nil {
-		params = &ListRegulationParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageRegulation(params, "", "")
+	response, err := c.StreamRegulation(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []NumbersV2Regulation
+	records := make([]NumbersV2Regulation, 0)
 
-	for response != nil {
-		records = append(records, response.Results...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRegulationResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListRegulationResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -161,18 +148,24 @@ func (c *ApiService) StreamRegulation(params *ListRegulationParams) (chan Number
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan NumbersV2Regulation, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Results {
-				channel <- response.Results[item]
+			responseRecords := response.Results
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRegulationResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListRegulationResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/numbers/v2/regulatory_compliance_supporting_documents.go
+++ b/rest/numbers/v2/regulatory_compliance_supporting_documents.go
@@ -174,28 +174,15 @@ func (c *ApiService) PageSupportingDocument(params *ListSupportingDocumentParams
 
 // Lists SupportingDocument records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSupportingDocument(params *ListSupportingDocumentParams) ([]NumbersV2SupportingDocument, error) {
-	if params == nil {
-		params = &ListSupportingDocumentParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageSupportingDocument(params, "", "")
+	response, err := c.StreamSupportingDocument(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []NumbersV2SupportingDocument
+	records := make([]NumbersV2SupportingDocument, 0)
 
-	for response != nil {
-		records = append(records, response.Results...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSupportingDocumentResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListSupportingDocumentResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -213,18 +200,24 @@ func (c *ApiService) StreamSupportingDocument(params *ListSupportingDocumentPara
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan NumbersV2SupportingDocument, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Results {
-				channel <- response.Results[item]
+			responseRecords := response.Results
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSupportingDocumentResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListSupportingDocumentResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/pricing/v1/phone_numbers_countries.go
+++ b/rest/pricing/v1/phone_numbers_countries.go
@@ -94,28 +94,15 @@ func (c *ApiService) PagePhoneNumberCountry(params *ListPhoneNumberCountryParams
 
 // Lists PhoneNumberCountry records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListPhoneNumberCountry(params *ListPhoneNumberCountryParams) ([]PricingV1PhoneNumberCountry, error) {
-	if params == nil {
-		params = &ListPhoneNumberCountryParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PagePhoneNumberCountry(params, "", "")
+	response, err := c.StreamPhoneNumberCountry(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []PricingV1PhoneNumberCountry
+	records := make([]PricingV1PhoneNumberCountry, 0)
 
-	for response != nil {
-		records = append(records, response.Countries...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListPhoneNumberCountryResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListPhoneNumberCountryResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -133,18 +120,24 @@ func (c *ApiService) StreamPhoneNumberCountry(params *ListPhoneNumberCountryPara
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan PricingV1PhoneNumberCountry, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Countries {
-				channel <- response.Countries[item]
+			responseRecords := response.Countries
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListPhoneNumberCountryResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListPhoneNumberCountryResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/pricing/v1/voice_countries.go
+++ b/rest/pricing/v1/voice_countries.go
@@ -94,28 +94,15 @@ func (c *ApiService) PageVoiceCountry(params *ListVoiceCountryParams, pageToken,
 
 // Lists VoiceCountry records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListVoiceCountry(params *ListVoiceCountryParams) ([]PricingV1VoiceCountry, error) {
-	if params == nil {
-		params = &ListVoiceCountryParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageVoiceCountry(params, "", "")
+	response, err := c.StreamVoiceCountry(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []PricingV1VoiceCountry
+	records := make([]PricingV1VoiceCountry, 0)
 
-	for response != nil {
-		records = append(records, response.Countries...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListVoiceCountryResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListVoiceCountryResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -133,18 +120,24 @@ func (c *ApiService) StreamVoiceCountry(params *ListVoiceCountryParams) (chan Pr
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan PricingV1VoiceCountry, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Countries {
-				channel <- response.Countries[item]
+			responseRecords := response.Countries
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListVoiceCountryResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListVoiceCountryResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/proxy/v1/services.go
+++ b/rest/proxy/v1/services.go
@@ -213,28 +213,15 @@ func (c *ApiService) PageService(params *ListServiceParams, pageToken, pageNumbe
 
 // Lists Service records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListService(params *ListServiceParams) ([]ProxyV1Service, error) {
-	if params == nil {
-		params = &ListServiceParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageService(params, "", "")
+	response, err := c.StreamService(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ProxyV1Service
+	records := make([]ProxyV1Service, 0)
 
-	for response != nil {
-		records = append(records, response.Services...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListServiceResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -252,18 +239,24 @@ func (c *ApiService) StreamService(params *ListServiceParams) (chan ProxyV1Servi
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ProxyV1Service, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Services {
-				channel <- response.Services[item]
+			responseRecords := response.Services
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/proxy/v1/services_phone_numbers.go
+++ b/rest/proxy/v1/services_phone_numbers.go
@@ -173,28 +173,15 @@ func (c *ApiService) PagePhoneNumber(ServiceSid string, params *ListPhoneNumberP
 
 // Lists PhoneNumber records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListPhoneNumber(ServiceSid string, params *ListPhoneNumberParams) ([]ProxyV1PhoneNumber, error) {
-	if params == nil {
-		params = &ListPhoneNumberParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PagePhoneNumber(ServiceSid, params, "", "")
+	response, err := c.StreamPhoneNumber(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ProxyV1PhoneNumber
+	records := make([]ProxyV1PhoneNumber, 0)
 
-	for response != nil {
-		records = append(records, response.PhoneNumbers...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListPhoneNumberResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListPhoneNumberResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -212,18 +199,24 @@ func (c *ApiService) StreamPhoneNumber(ServiceSid string, params *ListPhoneNumbe
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ProxyV1PhoneNumber, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.PhoneNumbers {
-				channel <- response.PhoneNumbers[item]
+			responseRecords := response.PhoneNumbers
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListPhoneNumberResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListPhoneNumberResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/proxy/v1/services_sessions_participants_message_interactions.go
+++ b/rest/proxy/v1/services_sessions_participants_message_interactions.go
@@ -152,28 +152,15 @@ func (c *ApiService) PageMessageInteraction(ServiceSid string, SessionSid string
 
 // Lists MessageInteraction records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMessageInteraction(ServiceSid string, SessionSid string, ParticipantSid string, params *ListMessageInteractionParams) ([]ProxyV1MessageInteraction, error) {
-	if params == nil {
-		params = &ListMessageInteractionParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageMessageInteraction(ServiceSid, SessionSid, ParticipantSid, params, "", "")
+	response, err := c.StreamMessageInteraction(ServiceSid, SessionSid, ParticipantSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ProxyV1MessageInteraction
+	records := make([]ProxyV1MessageInteraction, 0)
 
-	for response != nil {
-		records = append(records, response.Interactions...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListMessageInteractionResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListMessageInteractionResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -191,18 +178,24 @@ func (c *ApiService) StreamMessageInteraction(ServiceSid string, SessionSid stri
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ProxyV1MessageInteraction, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Interactions {
-				channel <- response.Interactions[item]
+			responseRecords := response.Interactions
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListMessageInteractionResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListMessageInteractionResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/proxy/v1/services_short_codes.go
+++ b/rest/proxy/v1/services_short_codes.go
@@ -155,28 +155,15 @@ func (c *ApiService) PageShortCode(ServiceSid string, params *ListShortCodeParam
 
 // Lists ShortCode records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListShortCode(ServiceSid string, params *ListShortCodeParams) ([]ProxyV1ShortCode, error) {
-	if params == nil {
-		params = &ListShortCodeParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageShortCode(ServiceSid, params, "", "")
+	response, err := c.StreamShortCode(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ProxyV1ShortCode
+	records := make([]ProxyV1ShortCode, 0)
 
-	for response != nil {
-		records = append(records, response.ShortCodes...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListShortCodeResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListShortCodeResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -194,18 +181,24 @@ func (c *ApiService) StreamShortCode(ServiceSid string, params *ListShortCodePar
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ProxyV1ShortCode, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.ShortCodes {
-				channel <- response.ShortCodes[item]
+			responseRecords := response.ShortCodes
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListShortCodeResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListShortCodeResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/serverless/v1/services.go
+++ b/rest/serverless/v1/services.go
@@ -177,28 +177,15 @@ func (c *ApiService) PageService(params *ListServiceParams, pageToken, pageNumbe
 
 // Lists Service records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListService(params *ListServiceParams) ([]ServerlessV1Service, error) {
-	if params == nil {
-		params = &ListServiceParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageService(params, "", "")
+	response, err := c.StreamService(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ServerlessV1Service
+	records := make([]ServerlessV1Service, 0)
 
-	for response != nil {
-		records = append(records, response.Services...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListServiceResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -216,18 +203,24 @@ func (c *ApiService) StreamService(params *ListServiceParams) (chan ServerlessV1
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ServerlessV1Service, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Services {
-				channel <- response.Services[item]
+			responseRecords := response.Services
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/serverless/v1/services_assets.go
+++ b/rest/serverless/v1/services_assets.go
@@ -155,28 +155,15 @@ func (c *ApiService) PageAsset(ServiceSid string, params *ListAssetParams, pageT
 
 // Lists Asset records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListAsset(ServiceSid string, params *ListAssetParams) ([]ServerlessV1Asset, error) {
-	if params == nil {
-		params = &ListAssetParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageAsset(ServiceSid, params, "", "")
+	response, err := c.StreamAsset(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ServerlessV1Asset
+	records := make([]ServerlessV1Asset, 0)
 
-	for response != nil {
-		records = append(records, response.Assets...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListAssetResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListAssetResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -194,18 +181,24 @@ func (c *ApiService) StreamAsset(ServiceSid string, params *ListAssetParams) (ch
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ServerlessV1Asset, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Assets {
-				channel <- response.Assets[item]
+			responseRecords := response.Assets
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListAssetResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListAssetResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/serverless/v1/services_assets_versions.go
+++ b/rest/serverless/v1/services_assets_versions.go
@@ -100,28 +100,15 @@ func (c *ApiService) PageAssetVersion(ServiceSid string, AssetSid string, params
 
 // Lists AssetVersion records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListAssetVersion(ServiceSid string, AssetSid string, params *ListAssetVersionParams) ([]ServerlessV1AssetVersion, error) {
-	if params == nil {
-		params = &ListAssetVersionParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageAssetVersion(ServiceSid, AssetSid, params, "", "")
+	response, err := c.StreamAssetVersion(ServiceSid, AssetSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ServerlessV1AssetVersion
+	records := make([]ServerlessV1AssetVersion, 0)
 
-	for response != nil {
-		records = append(records, response.AssetVersions...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListAssetVersionResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListAssetVersionResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -139,18 +126,24 @@ func (c *ApiService) StreamAssetVersion(ServiceSid string, AssetSid string, para
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ServerlessV1AssetVersion, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.AssetVersions {
-				channel <- response.AssetVersions[item]
+			responseRecords := response.AssetVersions
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListAssetVersionResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListAssetVersionResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/serverless/v1/services_builds.go
+++ b/rest/serverless/v1/services_builds.go
@@ -186,28 +186,15 @@ func (c *ApiService) PageBuild(ServiceSid string, params *ListBuildParams, pageT
 
 // Lists Build records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListBuild(ServiceSid string, params *ListBuildParams) ([]ServerlessV1Build, error) {
-	if params == nil {
-		params = &ListBuildParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageBuild(ServiceSid, params, "", "")
+	response, err := c.StreamBuild(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ServerlessV1Build
+	records := make([]ServerlessV1Build, 0)
 
-	for response != nil {
-		records = append(records, response.Builds...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListBuildResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListBuildResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -225,18 +212,24 @@ func (c *ApiService) StreamBuild(ServiceSid string, params *ListBuildParams) (ch
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ServerlessV1Build, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Builds {
-				channel <- response.Builds[item]
+			responseRecords := response.Builds
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListBuildResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListBuildResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/serverless/v1/services_environments_deployments.go
+++ b/rest/serverless/v1/services_environments_deployments.go
@@ -139,28 +139,15 @@ func (c *ApiService) PageDeployment(ServiceSid string, EnvironmentSid string, pa
 
 // Lists Deployment records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListDeployment(ServiceSid string, EnvironmentSid string, params *ListDeploymentParams) ([]ServerlessV1Deployment, error) {
-	if params == nil {
-		params = &ListDeploymentParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageDeployment(ServiceSid, EnvironmentSid, params, "", "")
+	response, err := c.StreamDeployment(ServiceSid, EnvironmentSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ServerlessV1Deployment
+	records := make([]ServerlessV1Deployment, 0)
 
-	for response != nil {
-		records = append(records, response.Deployments...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListDeploymentResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListDeploymentResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -178,18 +165,24 @@ func (c *ApiService) StreamDeployment(ServiceSid string, EnvironmentSid string, 
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ServerlessV1Deployment, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Deployments {
-				channel <- response.Deployments[item]
+			responseRecords := response.Deployments
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListDeploymentResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListDeploymentResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/serverless/v1/services_environments_variables.go
+++ b/rest/serverless/v1/services_environments_variables.go
@@ -168,28 +168,15 @@ func (c *ApiService) PageVariable(ServiceSid string, EnvironmentSid string, para
 
 // Lists Variable records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListVariable(ServiceSid string, EnvironmentSid string, params *ListVariableParams) ([]ServerlessV1Variable, error) {
-	if params == nil {
-		params = &ListVariableParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageVariable(ServiceSid, EnvironmentSid, params, "", "")
+	response, err := c.StreamVariable(ServiceSid, EnvironmentSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []ServerlessV1Variable
+	records := make([]ServerlessV1Variable, 0)
 
-	for response != nil {
-		records = append(records, response.Variables...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListVariableResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListVariableResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -207,18 +194,24 @@ func (c *ApiService) StreamVariable(ServiceSid string, EnvironmentSid string, pa
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan ServerlessV1Variable, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Variables {
-				channel <- response.Variables[item]
+			responseRecords := response.Variables
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListVariableResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListVariableResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/studio/v1/flows_engagements.go
+++ b/rest/studio/v1/flows_engagements.go
@@ -179,28 +179,15 @@ func (c *ApiService) PageEngagement(FlowSid string, params *ListEngagementParams
 
 // Lists Engagement records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListEngagement(FlowSid string, params *ListEngagementParams) ([]StudioV1Engagement, error) {
-	if params == nil {
-		params = &ListEngagementParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageEngagement(FlowSid, params, "", "")
+	response, err := c.StreamEngagement(FlowSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []StudioV1Engagement
+	records := make([]StudioV1Engagement, 0)
 
-	for response != nil {
-		records = append(records, response.Engagements...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListEngagementResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListEngagementResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -218,18 +205,24 @@ func (c *ApiService) StreamEngagement(FlowSid string, params *ListEngagementPara
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan StudioV1Engagement, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Engagements {
-				channel <- response.Engagements[item]
+			responseRecords := response.Engagements
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListEngagementResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListEngagementResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/studio/v1/flows_executions.go
+++ b/rest/studio/v1/flows_executions.go
@@ -198,28 +198,15 @@ func (c *ApiService) PageExecution(FlowSid string, params *ListExecutionParams, 
 
 // Lists Execution records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListExecution(FlowSid string, params *ListExecutionParams) ([]StudioV1Execution, error) {
-	if params == nil {
-		params = &ListExecutionParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageExecution(FlowSid, params, "", "")
+	response, err := c.StreamExecution(FlowSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []StudioV1Execution
+	records := make([]StudioV1Execution, 0)
 
-	for response != nil {
-		records = append(records, response.Executions...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListExecutionResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListExecutionResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -237,18 +224,24 @@ func (c *ApiService) StreamExecution(FlowSid string, params *ListExecutionParams
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan StudioV1Execution, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Executions {
-				channel <- response.Executions[item]
+			responseRecords := response.Executions
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListExecutionResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListExecutionResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/studio/v1/flows_executions_steps.go
+++ b/rest/studio/v1/flows_executions_steps.go
@@ -100,28 +100,15 @@ func (c *ApiService) PageExecutionStep(FlowSid string, ExecutionSid string, para
 
 // Lists ExecutionStep records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListExecutionStep(FlowSid string, ExecutionSid string, params *ListExecutionStepParams) ([]StudioV1ExecutionStep, error) {
-	if params == nil {
-		params = &ListExecutionStepParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageExecutionStep(FlowSid, ExecutionSid, params, "", "")
+	response, err := c.StreamExecutionStep(FlowSid, ExecutionSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []StudioV1ExecutionStep
+	records := make([]StudioV1ExecutionStep, 0)
 
-	for response != nil {
-		records = append(records, response.Steps...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListExecutionStepResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListExecutionStepResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -139,18 +126,24 @@ func (c *ApiService) StreamExecutionStep(FlowSid string, ExecutionSid string, pa
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan StudioV1ExecutionStep, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Steps {
-				channel <- response.Steps[item]
+			responseRecords := response.Steps
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListExecutionStepResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListExecutionStepResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/studio/v2/flows.go
+++ b/rest/studio/v2/flows.go
@@ -183,28 +183,15 @@ func (c *ApiService) PageFlow(params *ListFlowParams, pageToken, pageNumber stri
 
 // Lists Flow records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListFlow(params *ListFlowParams) ([]StudioV2Flow, error) {
-	if params == nil {
-		params = &ListFlowParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageFlow(params, "", "")
+	response, err := c.StreamFlow(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []StudioV2Flow
+	records := make([]StudioV2Flow, 0)
 
-	for response != nil {
-		records = append(records, response.Flows...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListFlowResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListFlowResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -222,18 +209,24 @@ func (c *ApiService) StreamFlow(params *ListFlowParams) (chan StudioV2Flow, erro
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan StudioV2Flow, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Flows {
-				channel <- response.Flows[item]
+			responseRecords := response.Flows
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListFlowResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListFlowResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/studio/v2/flows_executions_steps.go
+++ b/rest/studio/v2/flows_executions_steps.go
@@ -100,28 +100,15 @@ func (c *ApiService) PageExecutionStep(FlowSid string, ExecutionSid string, para
 
 // Lists ExecutionStep records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListExecutionStep(FlowSid string, ExecutionSid string, params *ListExecutionStepParams) ([]StudioV2ExecutionStep, error) {
-	if params == nil {
-		params = &ListExecutionStepParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageExecutionStep(FlowSid, ExecutionSid, params, "", "")
+	response, err := c.StreamExecutionStep(FlowSid, ExecutionSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []StudioV2ExecutionStep
+	records := make([]StudioV2ExecutionStep, 0)
 
-	for response != nil {
-		records = append(records, response.Steps...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListExecutionStepResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListExecutionStepResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -139,18 +126,24 @@ func (c *ApiService) StreamExecutionStep(FlowSid string, ExecutionSid string, pa
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan StudioV2ExecutionStep, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Steps {
-				channel <- response.Steps[item]
+			responseRecords := response.Steps
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListExecutionStepResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListExecutionStepResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/supersim/v1/commands.go
+++ b/rest/supersim/v1/commands.go
@@ -186,28 +186,15 @@ func (c *ApiService) PageCommand(params *ListCommandParams, pageToken, pageNumbe
 
 // Lists Command records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCommand(params *ListCommandParams) ([]SupersimV1Command, error) {
-	if params == nil {
-		params = &ListCommandParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageCommand(params, "", "")
+	response, err := c.StreamCommand(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []SupersimV1Command
+	records := make([]SupersimV1Command, 0)
 
-	for response != nil {
-		records = append(records, response.Commands...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCommandResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListCommandResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -225,18 +212,24 @@ func (c *ApiService) StreamCommand(params *ListCommandParams) (chan SupersimV1Co
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan SupersimV1Command, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Commands {
-				channel <- response.Commands[item]
+			responseRecords := response.Commands
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCommandResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListCommandResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/supersim/v1/e_sim_profiles.go
+++ b/rest/supersim/v1/e_sim_profiles.go
@@ -177,28 +177,15 @@ func (c *ApiService) PageEsimProfile(params *ListEsimProfileParams, pageToken, p
 
 // Lists EsimProfile records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListEsimProfile(params *ListEsimProfileParams) ([]SupersimV1EsimProfile, error) {
-	if params == nil {
-		params = &ListEsimProfileParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageEsimProfile(params, "", "")
+	response, err := c.StreamEsimProfile(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []SupersimV1EsimProfile
+	records := make([]SupersimV1EsimProfile, 0)
 
-	for response != nil {
-		records = append(records, response.EsimProfiles...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListEsimProfileResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListEsimProfileResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -216,18 +203,24 @@ func (c *ApiService) StreamEsimProfile(params *ListEsimProfileParams) (chan Supe
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan SupersimV1EsimProfile, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.EsimProfiles {
-				channel <- response.EsimProfiles[item]
+			responseRecords := response.EsimProfiles
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListEsimProfileResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListEsimProfileResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/supersim/v1/fleets.go
+++ b/rest/supersim/v1/fleets.go
@@ -240,28 +240,15 @@ func (c *ApiService) PageFleet(params *ListFleetParams, pageToken, pageNumber st
 
 // Lists Fleet records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListFleet(params *ListFleetParams) ([]SupersimV1Fleet, error) {
-	if params == nil {
-		params = &ListFleetParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageFleet(params, "", "")
+	response, err := c.StreamFleet(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []SupersimV1Fleet
+	records := make([]SupersimV1Fleet, 0)
 
-	for response != nil {
-		records = append(records, response.Fleets...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListFleetResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListFleetResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -279,18 +266,24 @@ func (c *ApiService) StreamFleet(params *ListFleetParams) (chan SupersimV1Fleet,
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan SupersimV1Fleet, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Fleets {
-				channel <- response.Fleets[item]
+			responseRecords := response.Fleets
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListFleetResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListFleetResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/supersim/v1/network_access_profiles_networks.go
+++ b/rest/supersim/v1/network_access_profiles_networks.go
@@ -155,28 +155,15 @@ func (c *ApiService) PageNetworkAccessProfileNetwork(NetworkAccessProfileSid str
 
 // Lists NetworkAccessProfileNetwork records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListNetworkAccessProfileNetwork(NetworkAccessProfileSid string, params *ListNetworkAccessProfileNetworkParams) ([]SupersimV1NetworkAccessProfileNetwork, error) {
-	if params == nil {
-		params = &ListNetworkAccessProfileNetworkParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageNetworkAccessProfileNetwork(NetworkAccessProfileSid, params, "", "")
+	response, err := c.StreamNetworkAccessProfileNetwork(NetworkAccessProfileSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []SupersimV1NetworkAccessProfileNetwork
+	records := make([]SupersimV1NetworkAccessProfileNetwork, 0)
 
-	for response != nil {
-		records = append(records, response.Networks...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListNetworkAccessProfileNetworkResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListNetworkAccessProfileNetworkResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -194,18 +181,24 @@ func (c *ApiService) StreamNetworkAccessProfileNetwork(NetworkAccessProfileSid s
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan SupersimV1NetworkAccessProfileNetwork, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Networks {
-				channel <- response.Networks[item]
+			responseRecords := response.Networks
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListNetworkAccessProfileNetworkResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListNetworkAccessProfileNetworkResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/supersim/v1/networks.go
+++ b/rest/supersim/v1/networks.go
@@ -122,28 +122,15 @@ func (c *ApiService) PageNetwork(params *ListNetworkParams, pageToken, pageNumbe
 
 // Lists Network records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListNetwork(params *ListNetworkParams) ([]SupersimV1Network, error) {
-	if params == nil {
-		params = &ListNetworkParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageNetwork(params, "", "")
+	response, err := c.StreamNetwork(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []SupersimV1Network
+	records := make([]SupersimV1Network, 0)
 
-	for response != nil {
-		records = append(records, response.Networks...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListNetworkResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListNetworkResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -161,18 +148,24 @@ func (c *ApiService) StreamNetwork(params *ListNetworkParams) (chan SupersimV1Ne
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan SupersimV1Network, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Networks {
-				channel <- response.Networks[item]
+			responseRecords := response.Networks
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListNetworkResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListNetworkResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/supersim/v1/sims.go
+++ b/rest/supersim/v1/sims.go
@@ -168,28 +168,15 @@ func (c *ApiService) PageSim(params *ListSimParams, pageToken, pageNumber string
 
 // Lists Sim records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSim(params *ListSimParams) ([]SupersimV1Sim, error) {
-	if params == nil {
-		params = &ListSimParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageSim(params, "", "")
+	response, err := c.StreamSim(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []SupersimV1Sim
+	records := make([]SupersimV1Sim, 0)
 
-	for response != nil {
-		records = append(records, response.Sims...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSimResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListSimResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -207,18 +194,24 @@ func (c *ApiService) StreamSim(params *ListSimParams) (chan SupersimV1Sim, error
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan SupersimV1Sim, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Sims {
-				channel <- response.Sims[item]
+			responseRecords := response.Sims
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSimResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListSimResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/supersim/v1/sms_commands.go
+++ b/rest/supersim/v1/sms_commands.go
@@ -186,28 +186,15 @@ func (c *ApiService) PageSmsCommand(params *ListSmsCommandParams, pageToken, pag
 
 // Lists SmsCommand records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSmsCommand(params *ListSmsCommandParams) ([]SupersimV1SmsCommand, error) {
-	if params == nil {
-		params = &ListSmsCommandParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageSmsCommand(params, "", "")
+	response, err := c.StreamSmsCommand(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []SupersimV1SmsCommand
+	records := make([]SupersimV1SmsCommand, 0)
 
-	for response != nil {
-		records = append(records, response.SmsCommands...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSmsCommandResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListSmsCommandResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -225,18 +212,24 @@ func (c *ApiService) StreamSmsCommand(params *ListSmsCommandParams) (chan Supers
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan SupersimV1SmsCommand, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.SmsCommands {
-				channel <- response.SmsCommands[item]
+			responseRecords := response.SmsCommands
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSmsCommandResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListSmsCommandResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/supersim/v1/usage_records.go
+++ b/rest/supersim/v1/usage_records.go
@@ -144,28 +144,15 @@ func (c *ApiService) PageUsageRecord(params *ListUsageRecordParams, pageToken, p
 
 // Lists UsageRecord records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUsageRecord(params *ListUsageRecordParams) ([]SupersimV1UsageRecord, error) {
-	if params == nil {
-		params = &ListUsageRecordParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageUsageRecord(params, "", "")
+	response, err := c.StreamUsageRecord(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []SupersimV1UsageRecord
+	records := make([]SupersimV1UsageRecord, 0)
 
-	for response != nil {
-		records = append(records, response.UsageRecords...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUsageRecordResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListUsageRecordResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -183,18 +170,24 @@ func (c *ApiService) StreamUsageRecord(params *ListUsageRecordParams) (chan Supe
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan SupersimV1UsageRecord, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.UsageRecords {
-				channel <- response.UsageRecords[item]
+			responseRecords := response.UsageRecords
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListUsageRecordResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListUsageRecordResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/sync/v1/services_documents_permissions.go
+++ b/rest/sync/v1/services_documents_permissions.go
@@ -120,28 +120,15 @@ func (c *ApiService) PageDocumentPermission(ServiceSid string, DocumentSid strin
 
 // Lists DocumentPermission records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListDocumentPermission(ServiceSid string, DocumentSid string, params *ListDocumentPermissionParams) ([]SyncV1DocumentPermission, error) {
-	if params == nil {
-		params = &ListDocumentPermissionParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageDocumentPermission(ServiceSid, DocumentSid, params, "", "")
+	response, err := c.StreamDocumentPermission(ServiceSid, DocumentSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []SyncV1DocumentPermission
+	records := make([]SyncV1DocumentPermission, 0)
 
-	for response != nil {
-		records = append(records, response.Permissions...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListDocumentPermissionResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListDocumentPermissionResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -159,18 +146,24 @@ func (c *ApiService) StreamDocumentPermission(ServiceSid string, DocumentSid str
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan SyncV1DocumentPermission, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Permissions {
-				channel <- response.Permissions[item]
+			responseRecords := response.Permissions
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListDocumentPermissionResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListDocumentPermissionResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/sync/v1/services_lists_permissions.go
+++ b/rest/sync/v1/services_lists_permissions.go
@@ -120,28 +120,15 @@ func (c *ApiService) PageSyncListPermission(ServiceSid string, ListSid string, p
 
 // Lists SyncListPermission records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSyncListPermission(ServiceSid string, ListSid string, params *ListSyncListPermissionParams) ([]SyncV1SyncListPermission, error) {
-	if params == nil {
-		params = &ListSyncListPermissionParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageSyncListPermission(ServiceSid, ListSid, params, "", "")
+	response, err := c.StreamSyncListPermission(ServiceSid, ListSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []SyncV1SyncListPermission
+	records := make([]SyncV1SyncListPermission, 0)
 
-	for response != nil {
-		records = append(records, response.Permissions...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSyncListPermissionResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListSyncListPermissionResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -159,18 +146,24 @@ func (c *ApiService) StreamSyncListPermission(ServiceSid string, ListSid string,
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan SyncV1SyncListPermission, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Permissions {
-				channel <- response.Permissions[item]
+			responseRecords := response.Permissions
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSyncListPermissionResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListSyncListPermissionResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/sync/v1/services_maps_permissions.go
+++ b/rest/sync/v1/services_maps_permissions.go
@@ -120,28 +120,15 @@ func (c *ApiService) PageSyncMapPermission(ServiceSid string, MapSid string, par
 
 // Lists SyncMapPermission records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSyncMapPermission(ServiceSid string, MapSid string, params *ListSyncMapPermissionParams) ([]SyncV1SyncMapPermission, error) {
-	if params == nil {
-		params = &ListSyncMapPermissionParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageSyncMapPermission(ServiceSid, MapSid, params, "", "")
+	response, err := c.StreamSyncMapPermission(ServiceSid, MapSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []SyncV1SyncMapPermission
+	records := make([]SyncV1SyncMapPermission, 0)
 
-	for response != nil {
-		records = append(records, response.Permissions...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSyncMapPermissionResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListSyncMapPermissionResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -159,18 +146,24 @@ func (c *ApiService) StreamSyncMapPermission(ServiceSid string, MapSid string, p
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan SyncV1SyncMapPermission, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Permissions {
-				channel <- response.Permissions[item]
+			responseRecords := response.Permissions
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSyncMapPermissionResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListSyncMapPermissionResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/sync/v1/services_streams.go
+++ b/rest/sync/v1/services_streams.go
@@ -164,28 +164,15 @@ func (c *ApiService) PageSyncStream(ServiceSid string, params *ListSyncStreamPar
 
 // Lists SyncStream records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSyncStream(ServiceSid string, params *ListSyncStreamParams) ([]SyncV1SyncStream, error) {
-	if params == nil {
-		params = &ListSyncStreamParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageSyncStream(ServiceSid, params, "", "")
+	response, err := c.StreamSyncStream(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []SyncV1SyncStream
+	records := make([]SyncV1SyncStream, 0)
 
-	for response != nil {
-		records = append(records, response.Streams...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSyncStreamResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListSyncStreamResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -203,18 +190,24 @@ func (c *ApiService) StreamSyncStream(ServiceSid string, params *ListSyncStreamP
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan SyncV1SyncStream, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Streams {
-				channel <- response.Streams[item]
+			responseRecords := response.Streams
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSyncStreamResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListSyncStreamResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/taskrouter/v1/workspaces.go
+++ b/rest/taskrouter/v1/workspaces.go
@@ -201,28 +201,15 @@ func (c *ApiService) PageWorkspace(params *ListWorkspaceParams, pageToken, pageN
 
 // Lists Workspace records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListWorkspace(params *ListWorkspaceParams) ([]TaskrouterV1Workspace, error) {
-	if params == nil {
-		params = &ListWorkspaceParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageWorkspace(params, "", "")
+	response, err := c.StreamWorkspace(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []TaskrouterV1Workspace
+	records := make([]TaskrouterV1Workspace, 0)
 
-	for response != nil {
-		records = append(records, response.Workspaces...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListWorkspaceResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListWorkspaceResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -240,18 +227,24 @@ func (c *ApiService) StreamWorkspace(params *ListWorkspaceParams) (chan Taskrout
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan TaskrouterV1Workspace, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Workspaces {
-				channel <- response.Workspaces[item]
+			responseRecords := response.Workspaces
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListWorkspaceResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListWorkspaceResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/taskrouter/v1/workspaces_activities.go
+++ b/rest/taskrouter/v1/workspaces_activities.go
@@ -179,28 +179,15 @@ func (c *ApiService) PageActivity(WorkspaceSid string, params *ListActivityParam
 
 // Lists Activity records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListActivity(WorkspaceSid string, params *ListActivityParams) ([]TaskrouterV1Activity, error) {
-	if params == nil {
-		params = &ListActivityParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageActivity(WorkspaceSid, params, "", "")
+	response, err := c.StreamActivity(WorkspaceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []TaskrouterV1Activity
+	records := make([]TaskrouterV1Activity, 0)
 
-	for response != nil {
-		records = append(records, response.Activities...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListActivityResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListActivityResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -218,18 +205,24 @@ func (c *ApiService) StreamActivity(WorkspaceSid string, params *ListActivityPar
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan TaskrouterV1Activity, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Activities {
-				channel <- response.Activities[item]
+			responseRecords := response.Activities
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListActivityResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListActivityResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/taskrouter/v1/workspaces_task_queues_statistics.go
+++ b/rest/taskrouter/v1/workspaces_task_queues_statistics.go
@@ -203,28 +203,15 @@ func (c *ApiService) PageTaskQueuesStatistics(WorkspaceSid string, params *ListT
 
 // Lists TaskQueuesStatistics records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListTaskQueuesStatistics(WorkspaceSid string, params *ListTaskQueuesStatisticsParams) ([]TaskrouterV1TaskQueuesStatistics, error) {
-	if params == nil {
-		params = &ListTaskQueuesStatisticsParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageTaskQueuesStatistics(WorkspaceSid, params, "", "")
+	response, err := c.StreamTaskQueuesStatistics(WorkspaceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []TaskrouterV1TaskQueuesStatistics
+	records := make([]TaskrouterV1TaskQueuesStatistics, 0)
 
-	for response != nil {
-		records = append(records, response.TaskQueuesStatistics...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListTaskQueuesStatisticsResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListTaskQueuesStatisticsResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -242,18 +229,24 @@ func (c *ApiService) StreamTaskQueuesStatistics(WorkspaceSid string, params *Lis
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan TaskrouterV1TaskQueuesStatistics, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.TaskQueuesStatistics {
-				channel <- response.TaskQueuesStatistics[item]
+			responseRecords := response.TaskQueuesStatistics
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListTaskQueuesStatisticsResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListTaskQueuesStatisticsResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/taskrouter/v1/workspaces_tasks_reservations.go
+++ b/rest/taskrouter/v1/workspaces_tasks_reservations.go
@@ -108,28 +108,15 @@ func (c *ApiService) PageTaskReservation(WorkspaceSid string, TaskSid string, pa
 
 // Lists TaskReservation records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListTaskReservation(WorkspaceSid string, TaskSid string, params *ListTaskReservationParams) ([]TaskrouterV1TaskReservation, error) {
-	if params == nil {
-		params = &ListTaskReservationParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageTaskReservation(WorkspaceSid, TaskSid, params, "", "")
+	response, err := c.StreamTaskReservation(WorkspaceSid, TaskSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []TaskrouterV1TaskReservation
+	records := make([]TaskrouterV1TaskReservation, 0)
 
-	for response != nil {
-		records = append(records, response.Reservations...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListTaskReservationResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListTaskReservationResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -147,18 +134,24 @@ func (c *ApiService) StreamTaskReservation(WorkspaceSid string, TaskSid string, 
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan TaskrouterV1TaskReservation, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Reservations {
-				channel <- response.Reservations[item]
+			responseRecords := response.Reservations
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListTaskReservationResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListTaskReservationResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/taskrouter/v1/workspaces_workers.go
+++ b/rest/taskrouter/v1/workspaces_workers.go
@@ -248,28 +248,15 @@ func (c *ApiService) PageWorker(WorkspaceSid string, params *ListWorkerParams, p
 
 // Lists Worker records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListWorker(WorkspaceSid string, params *ListWorkerParams) ([]TaskrouterV1Worker, error) {
-	if params == nil {
-		params = &ListWorkerParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageWorker(WorkspaceSid, params, "", "")
+	response, err := c.StreamWorker(WorkspaceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []TaskrouterV1Worker
+	records := make([]TaskrouterV1Worker, 0)
 
-	for response != nil {
-		records = append(records, response.Workers...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListWorkerResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListWorkerResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -287,18 +274,24 @@ func (c *ApiService) StreamWorker(WorkspaceSid string, params *ListWorkerParams)
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan TaskrouterV1Worker, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Workers {
-				channel <- response.Workers[item]
+			responseRecords := response.Workers
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListWorkerResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListWorkerResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/taskrouter/v1/workspaces_workflows.go
+++ b/rest/taskrouter/v1/workspaces_workflows.go
@@ -197,28 +197,15 @@ func (c *ApiService) PageWorkflow(WorkspaceSid string, params *ListWorkflowParam
 
 // Lists Workflow records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListWorkflow(WorkspaceSid string, params *ListWorkflowParams) ([]TaskrouterV1Workflow, error) {
-	if params == nil {
-		params = &ListWorkflowParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageWorkflow(WorkspaceSid, params, "", "")
+	response, err := c.StreamWorkflow(WorkspaceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []TaskrouterV1Workflow
+	records := make([]TaskrouterV1Workflow, 0)
 
-	for response != nil {
-		records = append(records, response.Workflows...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListWorkflowResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListWorkflowResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -236,18 +223,24 @@ func (c *ApiService) StreamWorkflow(WorkspaceSid string, params *ListWorkflowPar
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan TaskrouterV1Workflow, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Workflows {
-				channel <- response.Workflows[item]
+			responseRecords := response.Workflows
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListWorkflowResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListWorkflowResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/trunking/v1/trunks_credential_lists.go
+++ b/rest/trunking/v1/trunks_credential_lists.go
@@ -152,28 +152,15 @@ func (c *ApiService) PageCredentialList(TrunkSid string, params *ListCredentialL
 
 // Lists CredentialList records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCredentialList(TrunkSid string, params *ListCredentialListParams) ([]TrunkingV1CredentialList, error) {
-	if params == nil {
-		params = &ListCredentialListParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageCredentialList(TrunkSid, params, "", "")
+	response, err := c.StreamCredentialList(TrunkSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []TrunkingV1CredentialList
+	records := make([]TrunkingV1CredentialList, 0)
 
-	for response != nil {
-		records = append(records, response.CredentialLists...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCredentialListResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListCredentialListResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -191,18 +178,24 @@ func (c *ApiService) StreamCredentialList(TrunkSid string, params *ListCredentia
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan TrunkingV1CredentialList, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.CredentialLists {
-				channel <- response.CredentialLists[item]
+			responseRecords := response.CredentialLists
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCredentialListResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListCredentialListResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/trunking/v1/trunks_phone_numbers.go
+++ b/rest/trunking/v1/trunks_phone_numbers.go
@@ -152,28 +152,15 @@ func (c *ApiService) PagePhoneNumber(TrunkSid string, params *ListPhoneNumberPar
 
 // Lists PhoneNumber records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListPhoneNumber(TrunkSid string, params *ListPhoneNumberParams) ([]TrunkingV1PhoneNumber, error) {
-	if params == nil {
-		params = &ListPhoneNumberParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PagePhoneNumber(TrunkSid, params, "", "")
+	response, err := c.StreamPhoneNumber(TrunkSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []TrunkingV1PhoneNumber
+	records := make([]TrunkingV1PhoneNumber, 0)
 
-	for response != nil {
-		records = append(records, response.PhoneNumbers...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListPhoneNumberResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListPhoneNumberResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -191,18 +178,24 @@ func (c *ApiService) StreamPhoneNumber(TrunkSid string, params *ListPhoneNumberP
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan TrunkingV1PhoneNumber, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.PhoneNumbers {
-				channel <- response.PhoneNumbers[item]
+			responseRecords := response.PhoneNumbers
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListPhoneNumberResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListPhoneNumberResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/trusthub/v1/customer_profiles.go
+++ b/rest/trusthub/v1/customer_profiles.go
@@ -204,28 +204,15 @@ func (c *ApiService) PageCustomerProfile(params *ListCustomerProfileParams, page
 
 // Lists CustomerProfile records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCustomerProfile(params *ListCustomerProfileParams) ([]TrusthubV1CustomerProfile, error) {
-	if params == nil {
-		params = &ListCustomerProfileParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageCustomerProfile(params, "", "")
+	response, err := c.StreamCustomerProfile(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []TrusthubV1CustomerProfile
+	records := make([]TrusthubV1CustomerProfile, 0)
 
-	for response != nil {
-		records = append(records, response.Results...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCustomerProfileResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListCustomerProfileResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -243,18 +230,24 @@ func (c *ApiService) StreamCustomerProfile(params *ListCustomerProfileParams) (c
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan TrusthubV1CustomerProfile, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Results {
-				channel <- response.Results[item]
+			responseRecords := response.Results
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCustomerProfileResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListCustomerProfileResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/trusthub/v1/customer_profiles_channel_endpoint_assignments.go
+++ b/rest/trusthub/v1/customer_profiles_channel_endpoint_assignments.go
@@ -182,28 +182,15 @@ func (c *ApiService) PageCustomerProfileChannelEndpointAssignment(CustomerProfil
 
 // Lists CustomerProfileChannelEndpointAssignment records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCustomerProfileChannelEndpointAssignment(CustomerProfileSid string, params *ListCustomerProfileChannelEndpointAssignmentParams) ([]TrusthubV1CustomerProfileChannelEndpointAssignment, error) {
-	if params == nil {
-		params = &ListCustomerProfileChannelEndpointAssignmentParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageCustomerProfileChannelEndpointAssignment(CustomerProfileSid, params, "", "")
+	response, err := c.StreamCustomerProfileChannelEndpointAssignment(CustomerProfileSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []TrusthubV1CustomerProfileChannelEndpointAssignment
+	records := make([]TrusthubV1CustomerProfileChannelEndpointAssignment, 0)
 
-	for response != nil {
-		records = append(records, response.Results...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCustomerProfileChannelEndpointAssignmentResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListCustomerProfileChannelEndpointAssignmentResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -221,18 +208,24 @@ func (c *ApiService) StreamCustomerProfileChannelEndpointAssignment(CustomerProf
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan TrusthubV1CustomerProfileChannelEndpointAssignment, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Results {
-				channel <- response.Results[item]
+			responseRecords := response.Results
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCustomerProfileChannelEndpointAssignmentResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListCustomerProfileChannelEndpointAssignmentResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/trusthub/v1/customer_profiles_entity_assignments.go
+++ b/rest/trusthub/v1/customer_profiles_entity_assignments.go
@@ -155,28 +155,15 @@ func (c *ApiService) PageCustomerProfileEntityAssignment(CustomerProfileSid stri
 
 // Lists CustomerProfileEntityAssignment records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCustomerProfileEntityAssignment(CustomerProfileSid string, params *ListCustomerProfileEntityAssignmentParams) ([]TrusthubV1CustomerProfileEntityAssignment, error) {
-	if params == nil {
-		params = &ListCustomerProfileEntityAssignmentParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageCustomerProfileEntityAssignment(CustomerProfileSid, params, "", "")
+	response, err := c.StreamCustomerProfileEntityAssignment(CustomerProfileSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []TrusthubV1CustomerProfileEntityAssignment
+	records := make([]TrusthubV1CustomerProfileEntityAssignment, 0)
 
-	for response != nil {
-		records = append(records, response.Results...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCustomerProfileEntityAssignmentResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListCustomerProfileEntityAssignmentResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -194,18 +181,24 @@ func (c *ApiService) StreamCustomerProfileEntityAssignment(CustomerProfileSid st
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan TrusthubV1CustomerProfileEntityAssignment, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Results {
-				channel <- response.Results[item]
+			responseRecords := response.Results
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCustomerProfileEntityAssignmentResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListCustomerProfileEntityAssignmentResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/trusthub/v1/end_users.go
+++ b/rest/trusthub/v1/end_users.go
@@ -174,28 +174,15 @@ func (c *ApiService) PageEndUser(params *ListEndUserParams, pageToken, pageNumbe
 
 // Lists EndUser records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListEndUser(params *ListEndUserParams) ([]TrusthubV1EndUser, error) {
-	if params == nil {
-		params = &ListEndUserParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageEndUser(params, "", "")
+	response, err := c.StreamEndUser(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []TrusthubV1EndUser
+	records := make([]TrusthubV1EndUser, 0)
 
-	for response != nil {
-		records = append(records, response.Results...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListEndUserResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListEndUserResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -213,18 +200,24 @@ func (c *ApiService) StreamEndUser(params *ListEndUserParams) (chan TrusthubV1En
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan TrusthubV1EndUser, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Results {
-				channel <- response.Results[item]
+			responseRecords := response.Results
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListEndUserResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListEndUserResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/trusthub/v1/supporting_document_types.go
+++ b/rest/trusthub/v1/supporting_document_types.go
@@ -95,28 +95,15 @@ func (c *ApiService) PageSupportingDocumentType(params *ListSupportingDocumentTy
 
 // Lists SupportingDocumentType records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSupportingDocumentType(params *ListSupportingDocumentTypeParams) ([]TrusthubV1SupportingDocumentType, error) {
-	if params == nil {
-		params = &ListSupportingDocumentTypeParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageSupportingDocumentType(params, "", "")
+	response, err := c.StreamSupportingDocumentType(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []TrusthubV1SupportingDocumentType
+	records := make([]TrusthubV1SupportingDocumentType, 0)
 
-	for response != nil {
-		records = append(records, response.SupportingDocumentTypes...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSupportingDocumentTypeResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListSupportingDocumentTypeResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -134,18 +121,24 @@ func (c *ApiService) StreamSupportingDocumentType(params *ListSupportingDocument
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan TrusthubV1SupportingDocumentType, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.SupportingDocumentTypes {
-				channel <- response.SupportingDocumentTypes[item]
+			responseRecords := response.SupportingDocumentTypes
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSupportingDocumentTypeResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListSupportingDocumentTypeResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/trusthub/v1/supporting_documents.go
+++ b/rest/trusthub/v1/supporting_documents.go
@@ -174,28 +174,15 @@ func (c *ApiService) PageSupportingDocument(params *ListSupportingDocumentParams
 
 // Lists SupportingDocument records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSupportingDocument(params *ListSupportingDocumentParams) ([]TrusthubV1SupportingDocument, error) {
-	if params == nil {
-		params = &ListSupportingDocumentParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageSupportingDocument(params, "", "")
+	response, err := c.StreamSupportingDocument(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []TrusthubV1SupportingDocument
+	records := make([]TrusthubV1SupportingDocument, 0)
 
-	for response != nil {
-		records = append(records, response.Results...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSupportingDocumentResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListSupportingDocumentResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -213,18 +200,24 @@ func (c *ApiService) StreamSupportingDocument(params *ListSupportingDocumentPara
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan TrusthubV1SupportingDocument, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Results {
-				channel <- response.Results[item]
+			responseRecords := response.Results
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSupportingDocumentResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListSupportingDocumentResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/trusthub/v1/trust_products_channel_endpoint_assignments.go
+++ b/rest/trusthub/v1/trust_products_channel_endpoint_assignments.go
@@ -182,28 +182,15 @@ func (c *ApiService) PageTrustProductChannelEndpointAssignment(TrustProductSid s
 
 // Lists TrustProductChannelEndpointAssignment records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListTrustProductChannelEndpointAssignment(TrustProductSid string, params *ListTrustProductChannelEndpointAssignmentParams) ([]TrusthubV1TrustProductChannelEndpointAssignment, error) {
-	if params == nil {
-		params = &ListTrustProductChannelEndpointAssignmentParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageTrustProductChannelEndpointAssignment(TrustProductSid, params, "", "")
+	response, err := c.StreamTrustProductChannelEndpointAssignment(TrustProductSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []TrusthubV1TrustProductChannelEndpointAssignment
+	records := make([]TrusthubV1TrustProductChannelEndpointAssignment, 0)
 
-	for response != nil {
-		records = append(records, response.Results...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListTrustProductChannelEndpointAssignmentResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListTrustProductChannelEndpointAssignmentResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -221,18 +208,24 @@ func (c *ApiService) StreamTrustProductChannelEndpointAssignment(TrustProductSid
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan TrusthubV1TrustProductChannelEndpointAssignment, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Results {
-				channel <- response.Results[item]
+			responseRecords := response.Results
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListTrustProductChannelEndpointAssignmentResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListTrustProductChannelEndpointAssignmentResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/trusthub/v1/trust_products_entity_assignments.go
+++ b/rest/trusthub/v1/trust_products_entity_assignments.go
@@ -155,28 +155,15 @@ func (c *ApiService) PageTrustProductEntityAssignment(TrustProductSid string, pa
 
 // Lists TrustProductEntityAssignment records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListTrustProductEntityAssignment(TrustProductSid string, params *ListTrustProductEntityAssignmentParams) ([]TrusthubV1TrustProductEntityAssignment, error) {
-	if params == nil {
-		params = &ListTrustProductEntityAssignmentParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageTrustProductEntityAssignment(TrustProductSid, params, "", "")
+	response, err := c.StreamTrustProductEntityAssignment(TrustProductSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []TrusthubV1TrustProductEntityAssignment
+	records := make([]TrusthubV1TrustProductEntityAssignment, 0)
 
-	for response != nil {
-		records = append(records, response.Results...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListTrustProductEntityAssignmentResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListTrustProductEntityAssignmentResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -194,18 +181,24 @@ func (c *ApiService) StreamTrustProductEntityAssignment(TrustProductSid string, 
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan TrusthubV1TrustProductEntityAssignment, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Results {
-				channel <- response.Results[item]
+			responseRecords := response.Results
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListTrustProductEntityAssignmentResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListTrustProductEntityAssignmentResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/trusthub/v1/trust_products_evaluations.go
+++ b/rest/trusthub/v1/trust_products_evaluations.go
@@ -136,28 +136,15 @@ func (c *ApiService) PageTrustProductEvaluation(TrustProductSid string, params *
 
 // Lists TrustProductEvaluation records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListTrustProductEvaluation(TrustProductSid string, params *ListTrustProductEvaluationParams) ([]TrusthubV1TrustProductEvaluation, error) {
-	if params == nil {
-		params = &ListTrustProductEvaluationParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageTrustProductEvaluation(TrustProductSid, params, "", "")
+	response, err := c.StreamTrustProductEvaluation(TrustProductSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []TrusthubV1TrustProductEvaluation
+	records := make([]TrusthubV1TrustProductEvaluation, 0)
 
-	for response != nil {
-		records = append(records, response.Results...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListTrustProductEvaluationResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListTrustProductEvaluationResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -175,18 +162,24 @@ func (c *ApiService) StreamTrustProductEvaluation(TrustProductSid string, params
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan TrusthubV1TrustProductEvaluation, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Results {
-				channel <- response.Results[item]
+			responseRecords := response.Results
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListTrustProductEvaluationResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListTrustProductEvaluationResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/verify/v2/attempts.go
+++ b/rest/verify/v2/attempts.go
@@ -168,28 +168,15 @@ func (c *ApiService) PageVerificationAttempt(params *ListVerificationAttemptPara
 
 // Lists VerificationAttempt records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListVerificationAttempt(params *ListVerificationAttemptParams) ([]VerifyV2VerificationAttempt, error) {
-	if params == nil {
-		params = &ListVerificationAttemptParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageVerificationAttempt(params, "", "")
+	response, err := c.StreamVerificationAttempt(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []VerifyV2VerificationAttempt
+	records := make([]VerifyV2VerificationAttempt, 0)
 
-	for response != nil {
-		records = append(records, response.Attempts...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListVerificationAttemptResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListVerificationAttemptResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -207,18 +194,24 @@ func (c *ApiService) StreamVerificationAttempt(params *ListVerificationAttemptPa
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan VerifyV2VerificationAttempt, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Attempts {
-				channel <- response.Attempts[item]
+			responseRecords := response.Attempts
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListVerificationAttemptResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListVerificationAttemptResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/verify/v2/services.go
+++ b/rest/verify/v2/services.go
@@ -294,28 +294,15 @@ func (c *ApiService) PageService(params *ListServiceParams, pageToken, pageNumbe
 
 // Lists Service records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListService(params *ListServiceParams) ([]VerifyV2Service, error) {
-	if params == nil {
-		params = &ListServiceParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageService(params, "", "")
+	response, err := c.StreamService(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []VerifyV2Service
+	records := make([]VerifyV2Service, 0)
 
-	for response != nil {
-		records = append(records, response.Services...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListServiceResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -333,18 +320,24 @@ func (c *ApiService) StreamService(params *ListServiceParams) (chan VerifyV2Serv
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan VerifyV2Service, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Services {
-				channel <- response.Services[item]
+			responseRecords := response.Services
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListServiceResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/verify/v2/services_entities.go
+++ b/rest/verify/v2/services_entities.go
@@ -155,28 +155,15 @@ func (c *ApiService) PageEntity(ServiceSid string, params *ListEntityParams, pag
 
 // Lists Entity records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListEntity(ServiceSid string, params *ListEntityParams) ([]VerifyV2Entity, error) {
-	if params == nil {
-		params = &ListEntityParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageEntity(ServiceSid, params, "", "")
+	response, err := c.StreamEntity(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []VerifyV2Entity
+	records := make([]VerifyV2Entity, 0)
 
-	for response != nil {
-		records = append(records, response.Entities...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListEntityResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListEntityResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -194,18 +181,24 @@ func (c *ApiService) StreamEntity(ServiceSid string, params *ListEntityParams) (
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan VerifyV2Entity, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Entities {
-				channel <- response.Entities[item]
+			responseRecords := response.Entities
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListEntityResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListEntityResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/verify/v2/services_messaging_configurations.go
+++ b/rest/verify/v2/services_messaging_configurations.go
@@ -164,28 +164,15 @@ func (c *ApiService) PageMessagingConfiguration(ServiceSid string, params *ListM
 
 // Lists MessagingConfiguration records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMessagingConfiguration(ServiceSid string, params *ListMessagingConfigurationParams) ([]VerifyV2MessagingConfiguration, error) {
-	if params == nil {
-		params = &ListMessagingConfigurationParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageMessagingConfiguration(ServiceSid, params, "", "")
+	response, err := c.StreamMessagingConfiguration(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []VerifyV2MessagingConfiguration
+	records := make([]VerifyV2MessagingConfiguration, 0)
 
-	for response != nil {
-		records = append(records, response.MessagingConfigurations...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListMessagingConfigurationResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListMessagingConfigurationResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -203,18 +190,24 @@ func (c *ApiService) StreamMessagingConfiguration(ServiceSid string, params *Lis
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan VerifyV2MessagingConfiguration, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.MessagingConfigurations {
-				channel <- response.MessagingConfigurations[item]
+			responseRecords := response.MessagingConfigurations
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListMessagingConfigurationResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListMessagingConfigurationResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/verify/v2/services_rate_limits.go
+++ b/rest/verify/v2/services_rate_limits.go
@@ -164,28 +164,15 @@ func (c *ApiService) PageRateLimit(ServiceSid string, params *ListRateLimitParam
 
 // Lists RateLimit records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRateLimit(ServiceSid string, params *ListRateLimitParams) ([]VerifyV2RateLimit, error) {
-	if params == nil {
-		params = &ListRateLimitParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageRateLimit(ServiceSid, params, "", "")
+	response, err := c.StreamRateLimit(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []VerifyV2RateLimit
+	records := make([]VerifyV2RateLimit, 0)
 
-	for response != nil {
-		records = append(records, response.RateLimits...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRateLimitResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListRateLimitResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -203,18 +190,24 @@ func (c *ApiService) StreamRateLimit(ServiceSid string, params *ListRateLimitPar
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan VerifyV2RateLimit, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.RateLimits {
-				channel <- response.RateLimits[item]
+			responseRecords := response.RateLimits
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRateLimitResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListRateLimitResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/verify/v2/services_rate_limits_buckets.go
+++ b/rest/verify/v2/services_rate_limits_buckets.go
@@ -168,28 +168,15 @@ func (c *ApiService) PageBucket(ServiceSid string, RateLimitSid string, params *
 
 // Lists Bucket records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListBucket(ServiceSid string, RateLimitSid string, params *ListBucketParams) ([]VerifyV2Bucket, error) {
-	if params == nil {
-		params = &ListBucketParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageBucket(ServiceSid, RateLimitSid, params, "", "")
+	response, err := c.StreamBucket(ServiceSid, RateLimitSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []VerifyV2Bucket
+	records := make([]VerifyV2Bucket, 0)
 
-	for response != nil {
-		records = append(records, response.Buckets...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListBucketResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListBucketResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -207,18 +194,24 @@ func (c *ApiService) StreamBucket(ServiceSid string, RateLimitSid string, params
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan VerifyV2Bucket, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Buckets {
-				channel <- response.Buckets[item]
+			responseRecords := response.Buckets
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListBucketResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListBucketResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/verify/v2/services_webhooks.go
+++ b/rest/verify/v2/services_webhooks.go
@@ -193,28 +193,15 @@ func (c *ApiService) PageWebhook(ServiceSid string, params *ListWebhookParams, p
 
 // Lists Webhook records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListWebhook(ServiceSid string, params *ListWebhookParams) ([]VerifyV2Webhook, error) {
-	if params == nil {
-		params = &ListWebhookParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageWebhook(ServiceSid, params, "", "")
+	response, err := c.StreamWebhook(ServiceSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []VerifyV2Webhook
+	records := make([]VerifyV2Webhook, 0)
 
-	for response != nil {
-		records = append(records, response.Webhooks...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListWebhookResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListWebhookResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -232,18 +219,24 @@ func (c *ApiService) StreamWebhook(ServiceSid string, params *ListWebhookParams)
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan VerifyV2Webhook, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Webhooks {
-				channel <- response.Webhooks[item]
+			responseRecords := response.Webhooks
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListWebhookResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListWebhookResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/video/v1/composition_hooks.go
+++ b/rest/video/v1/composition_hooks.go
@@ -277,28 +277,15 @@ func (c *ApiService) PageCompositionHook(params *ListCompositionHookParams, page
 
 // Lists CompositionHook records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCompositionHook(params *ListCompositionHookParams) ([]VideoV1CompositionHook, error) {
-	if params == nil {
-		params = &ListCompositionHookParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageCompositionHook(params, "", "")
+	response, err := c.StreamCompositionHook(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []VideoV1CompositionHook
+	records := make([]VideoV1CompositionHook, 0)
 
-	for response != nil {
-		records = append(records, response.CompositionHooks...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCompositionHookResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListCompositionHookResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -316,18 +303,24 @@ func (c *ApiService) StreamCompositionHook(params *ListCompositionHookParams) (c
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan VideoV1CompositionHook, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.CompositionHooks {
-				channel <- response.CompositionHooks[item]
+			responseRecords := response.CompositionHooks
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCompositionHookResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListCompositionHookResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/video/v1/compositions.go
+++ b/rest/video/v1/compositions.go
@@ -268,28 +268,15 @@ func (c *ApiService) PageComposition(params *ListCompositionParams, pageToken, p
 
 // Lists Composition records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListComposition(params *ListCompositionParams) ([]VideoV1Composition, error) {
-	if params == nil {
-		params = &ListCompositionParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageComposition(params, "", "")
+	response, err := c.StreamComposition(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []VideoV1Composition
+	records := make([]VideoV1Composition, 0)
 
-	for response != nil {
-		records = append(records, response.Compositions...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCompositionResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListCompositionResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -307,18 +294,24 @@ func (c *ApiService) StreamComposition(params *ListCompositionParams) (chan Vide
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan VideoV1Composition, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Compositions {
-				channel <- response.Compositions[item]
+			responseRecords := response.Compositions
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCompositionResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListCompositionResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/video/v1/recordings.go
+++ b/rest/video/v1/recordings.go
@@ -170,28 +170,15 @@ func (c *ApiService) PageRecording(params *ListRecordingParams, pageToken, pageN
 
 // Lists Recording records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRecording(params *ListRecordingParams) ([]VideoV1Recording, error) {
-	if params == nil {
-		params = &ListRecordingParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageRecording(params, "", "")
+	response, err := c.StreamRecording(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []VideoV1Recording
+	records := make([]VideoV1Recording, 0)
 
-	for response != nil {
-		records = append(records, response.Recordings...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRecordingResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListRecordingResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -209,18 +196,24 @@ func (c *ApiService) StreamRecording(params *ListRecordingParams) (chan VideoV1R
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan VideoV1Recording, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Recordings {
-				channel <- response.Recordings[item]
+			responseRecords := response.Recordings
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRecordingResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListRecordingResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/video/v1/rooms_participants.go
+++ b/rest/video/v1/rooms_participants.go
@@ -134,28 +134,15 @@ func (c *ApiService) PageRoomParticipant(RoomSid string, params *ListRoomPartici
 
 // Lists RoomParticipant records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRoomParticipant(RoomSid string, params *ListRoomParticipantParams) ([]VideoV1RoomParticipant, error) {
-	if params == nil {
-		params = &ListRoomParticipantParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageRoomParticipant(RoomSid, params, "", "")
+	response, err := c.StreamRoomParticipant(RoomSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []VideoV1RoomParticipant
+	records := make([]VideoV1RoomParticipant, 0)
 
-	for response != nil {
-		records = append(records, response.Participants...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRoomParticipantResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListRoomParticipantResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -173,18 +160,24 @@ func (c *ApiService) StreamRoomParticipant(RoomSid string, params *ListRoomParti
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan VideoV1RoomParticipant, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Participants {
-				channel <- response.Participants[item]
+			responseRecords := response.Participants
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRoomParticipantResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListRoomParticipantResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/video/v1/rooms_participants_subscribed_tracks.go
+++ b/rest/video/v1/rooms_participants_subscribed_tracks.go
@@ -100,28 +100,15 @@ func (c *ApiService) PageRoomParticipantSubscribedTrack(RoomSid string, Particip
 
 // Lists RoomParticipantSubscribedTrack records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRoomParticipantSubscribedTrack(RoomSid string, ParticipantSid string, params *ListRoomParticipantSubscribedTrackParams) ([]VideoV1RoomParticipantSubscribedTrack, error) {
-	if params == nil {
-		params = &ListRoomParticipantSubscribedTrackParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageRoomParticipantSubscribedTrack(RoomSid, ParticipantSid, params, "", "")
+	response, err := c.StreamRoomParticipantSubscribedTrack(RoomSid, ParticipantSid, params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []VideoV1RoomParticipantSubscribedTrack
+	records := make([]VideoV1RoomParticipantSubscribedTrack, 0)
 
-	for response != nil {
-		records = append(records, response.SubscribedTracks...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRoomParticipantSubscribedTrackResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListRoomParticipantSubscribedTrackResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -139,18 +126,24 @@ func (c *ApiService) StreamRoomParticipantSubscribedTrack(RoomSid string, Partic
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan VideoV1RoomParticipantSubscribedTrack, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.SubscribedTracks {
-				channel <- response.SubscribedTracks[item]
+			responseRecords := response.SubscribedTracks
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRoomParticipantSubscribedTrackResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListRoomParticipantSubscribedTrackResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/voice/v1/byoc_trunks.go
+++ b/rest/voice/v1/byoc_trunks.go
@@ -228,28 +228,15 @@ func (c *ApiService) PageByocTrunk(params *ListByocTrunkParams, pageToken, pageN
 
 // Lists ByocTrunk records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListByocTrunk(params *ListByocTrunkParams) ([]VoiceV1ByocTrunk, error) {
-	if params == nil {
-		params = &ListByocTrunkParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageByocTrunk(params, "", "")
+	response, err := c.StreamByocTrunk(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []VoiceV1ByocTrunk
+	records := make([]VoiceV1ByocTrunk, 0)
 
-	for response != nil {
-		records = append(records, response.ByocTrunks...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListByocTrunkResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListByocTrunkResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -267,18 +254,24 @@ func (c *ApiService) StreamByocTrunk(params *ListByocTrunkParams) (chan VoiceV1B
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan VoiceV1ByocTrunk, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.ByocTrunks {
-				channel <- response.ByocTrunks[item]
+			responseRecords := response.ByocTrunks
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListByocTrunkResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListByocTrunkResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/voice/v1/dialing_permissions_countries.go
+++ b/rest/voice/v1/dialing_permissions_countries.go
@@ -149,28 +149,15 @@ func (c *ApiService) PageDialingPermissionsCountry(params *ListDialingPermission
 
 // Lists DialingPermissionsCountry records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListDialingPermissionsCountry(params *ListDialingPermissionsCountryParams) ([]VoiceV1DialingPermissionsCountry, error) {
-	if params == nil {
-		params = &ListDialingPermissionsCountryParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageDialingPermissionsCountry(params, "", "")
+	response, err := c.StreamDialingPermissionsCountry(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []VoiceV1DialingPermissionsCountry
+	records := make([]VoiceV1DialingPermissionsCountry, 0)
 
-	for response != nil {
-		records = append(records, response.Content...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListDialingPermissionsCountryResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListDialingPermissionsCountryResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -188,18 +175,24 @@ func (c *ApiService) StreamDialingPermissionsCountry(params *ListDialingPermissi
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan VoiceV1DialingPermissionsCountry, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Content {
-				channel <- response.Content[item]
+			responseRecords := response.Content
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListDialingPermissionsCountryResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListDialingPermissionsCountryResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/wireless/v1/rate_plans.go
+++ b/rest/wireless/v1/rate_plans.go
@@ -239,28 +239,15 @@ func (c *ApiService) PageRatePlan(params *ListRatePlanParams, pageToken, pageNum
 
 // Lists RatePlan records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRatePlan(params *ListRatePlanParams) ([]WirelessV1RatePlan, error) {
-	if params == nil {
-		params = &ListRatePlanParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageRatePlan(params, "", "")
+	response, err := c.StreamRatePlan(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []WirelessV1RatePlan
+	records := make([]WirelessV1RatePlan, 0)
 
-	for response != nil {
-		records = append(records, response.RatePlans...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRatePlanResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListRatePlanResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -278,18 +265,24 @@ func (c *ApiService) StreamRatePlan(params *ListRatePlanParams) (chan WirelessV1
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan WirelessV1RatePlan, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.RatePlans {
-				channel <- response.RatePlans[item]
+			responseRecords := response.RatePlans
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListRatePlanResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListRatePlanResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/wireless/v1/sims.go
+++ b/rest/wireless/v1/sims.go
@@ -158,28 +158,15 @@ func (c *ApiService) PageSim(params *ListSimParams, pageToken, pageNumber string
 
 // Lists Sim records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSim(params *ListSimParams) ([]WirelessV1Sim, error) {
-	if params == nil {
-		params = &ListSimParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageSim(params, "", "")
+	response, err := c.StreamSim(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []WirelessV1Sim
+	records := make([]WirelessV1Sim, 0)
 
-	for response != nil {
-		records = append(records, response.Sims...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSimResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListSimResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -197,18 +184,24 @@ func (c *ApiService) StreamSim(params *ListSimParams) (chan WirelessV1Sim, error
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan WirelessV1Sim, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.Sims {
-				channel <- response.Sims[item]
+			responseRecords := response.Sims
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListSimResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListSimResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}

--- a/rest/wireless/v1/usage_records.go
+++ b/rest/wireless/v1/usage_records.go
@@ -99,28 +99,15 @@ func (c *ApiService) PageAccountUsageRecord(params *ListAccountUsageRecordParams
 
 // Lists AccountUsageRecord records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListAccountUsageRecord(params *ListAccountUsageRecordParams) ([]WirelessV1AccountUsageRecord, error) {
-	if params == nil {
-		params = &ListAccountUsageRecordParams{}
-	}
-	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-	response, err := c.PageAccountUsageRecord(params, "", "")
+	response, err := c.StreamAccountUsageRecord(params)
 	if err != nil {
 		return nil, err
 	}
 
-	curRecord := 0
-	var records []WirelessV1AccountUsageRecord
+	records := make([]WirelessV1AccountUsageRecord, 0)
 
-	for response != nil {
-		records = append(records, response.UsageRecords...)
-
-		var record interface{}
-		if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListAccountUsageRecordResponse); record == nil || err != nil {
-			return records, err
-		}
-
-		response = record.(*ListAccountUsageRecordResponse)
+	for record := range response {
+		records = append(records, record)
 	}
 
 	return records, err
@@ -138,18 +125,24 @@ func (c *ApiService) StreamAccountUsageRecord(params *ListAccountUsageRecordPara
 		return nil, err
 	}
 
-	curRecord := 0
+	curRecord := 1
 	//set buffer size of the channel to 1
 	channel := make(chan WirelessV1AccountUsageRecord, 1)
 
 	go func() {
 		for response != nil {
-			for item := range response.UsageRecords {
-				channel <- response.UsageRecords[item]
+			responseRecords := response.UsageRecords
+			for item := range responseRecords {
+				channel <- responseRecords[item]
+				curRecord += 1
+				if params.Limit != nil && *params.Limit < curRecord {
+					close(channel)
+					return
+				}
 			}
 
 			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListAccountUsageRecordResponse); record == nil || err != nil {
+			if record, err = client.GetNext(c.baseURL, response, c.getNextListAccountUsageRecordResponse); record == nil || err != nil {
 				close(channel)
 				return
 			}


### PR DESCRIPTION
Fixes bugs where limit param was not always enforced and empty results caused an error when attempting to fetch next page.

Fixes https://github.com/twilio/twilio-go/issues/146