### PR TITLE
feat: twilio-go stream functions also return error channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ package main
 
 import (
 	"github.com/twilio/twilio-go"
-	"os"
 )
 
 func main() {
@@ -128,7 +127,6 @@ import (
 	"fmt"
 	"github.com/twilio/twilio-go"
 	openapi "github.com/twilio/twilio-go/rest/api/v2010"
-	"os"
 )
 
 func main() {
@@ -243,7 +241,6 @@ func main() {
 		fmt.Println(*resp.Sid)
 	}
 }
-
 ```
 
 ### Create a Studio Flow
@@ -254,7 +251,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/twilio/twilio-go"
 	openapi "github.com/twilio/twilio-go/rest/studio/v2"
@@ -309,8 +305,9 @@ receive (limit) and the maximum size you want each page fetch to be (pageSize). 
 for you.
 
 `List` eagerly fetches all records and returns them as a list, whereas `Stream` streams the records and lazily retrieves
-the pages as you iterate over the collection. You can also page manually using the `PageXxx` function in each of the
-apis.
+the pages as you iterate over the collection. Also, `List` returns no records if any errors are encountered while paging,
+whereas `Stream` returns all records up until encountering an error. You can also page manually using the `PageXxx`
+function in each of the apis.
 
 ```go
 package main
@@ -348,7 +345,6 @@ func main() {
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"github.com/twilio/twilio-go"
 	openapi "github.com/twilio/twilio-go/rest/api/v2010"

--- a/rest/api/v2010/accounts.go
+++ b/rest/api/v2010/accounts.go
@@ -150,60 +150,70 @@ func (c *ApiService) PageAccount(params *ListAccountParams, pageToken, pageNumbe
 
 // Lists Account records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListAccount(params *ListAccountParams) ([]ApiV2010Account, error) {
-	response, err := c.StreamAccount(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamAccount(params)
 
 	records := make([]ApiV2010Account, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Account records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamAccount(params *ListAccountParams) (chan ApiV2010Account, error) {
+func (c *ApiService) StreamAccount(params *ListAccountParams) (chan ApiV2010Account, chan error) {
 	if params == nil {
 		params = &ListAccountParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010Account, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageAccount(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamAccount(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamAccount(response *ListAccountResponse, params *ListAccountParams, recordChannel chan ApiV2010Account, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010Account, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Accounts
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListAccountResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Accounts
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListAccountResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListAccountResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListAccountResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListAccountResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_addresses_dependent_phone_numbers.go
+++ b/rest/api/v2010/accounts_addresses_dependent_phone_numbers.go
@@ -85,60 +85,70 @@ func (c *ApiService) PageDependentPhoneNumber(AddressSid string, params *ListDep
 
 // Lists DependentPhoneNumber records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListDependentPhoneNumber(AddressSid string, params *ListDependentPhoneNumberParams) ([]ApiV2010DependentPhoneNumber, error) {
-	response, err := c.StreamDependentPhoneNumber(AddressSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamDependentPhoneNumber(AddressSid, params)
 
 	records := make([]ApiV2010DependentPhoneNumber, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams DependentPhoneNumber records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamDependentPhoneNumber(AddressSid string, params *ListDependentPhoneNumberParams) (chan ApiV2010DependentPhoneNumber, error) {
+func (c *ApiService) StreamDependentPhoneNumber(AddressSid string, params *ListDependentPhoneNumberParams) (chan ApiV2010DependentPhoneNumber, chan error) {
 	if params == nil {
 		params = &ListDependentPhoneNumberParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010DependentPhoneNumber, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageDependentPhoneNumber(AddressSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamDependentPhoneNumber(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamDependentPhoneNumber(response *ListDependentPhoneNumberResponse, params *ListDependentPhoneNumberParams, recordChannel chan ApiV2010DependentPhoneNumber, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010DependentPhoneNumber, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.DependentPhoneNumbers
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListDependentPhoneNumberResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.DependentPhoneNumbers
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListDependentPhoneNumberResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListDependentPhoneNumberResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListDependentPhoneNumberResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListDependentPhoneNumberResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_applications.go
+++ b/rest/api/v2010/accounts_applications.go
@@ -340,60 +340,70 @@ func (c *ApiService) PageApplication(params *ListApplicationParams, pageToken, p
 
 // Lists Application records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListApplication(params *ListApplicationParams) ([]ApiV2010Application, error) {
-	response, err := c.StreamApplication(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamApplication(params)
 
 	records := make([]ApiV2010Application, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Application records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamApplication(params *ListApplicationParams) (chan ApiV2010Application, error) {
+func (c *ApiService) StreamApplication(params *ListApplicationParams) (chan ApiV2010Application, chan error) {
 	if params == nil {
 		params = &ListApplicationParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010Application, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageApplication(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamApplication(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamApplication(response *ListApplicationResponse, params *ListApplicationParams, recordChannel chan ApiV2010Application, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010Application, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Applications
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListApplicationResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Applications
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListApplicationResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListApplicationResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListApplicationResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListApplicationResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_authorized_connect_apps.go
+++ b/rest/api/v2010/accounts_authorized_connect_apps.go
@@ -123,60 +123,70 @@ func (c *ApiService) PageAuthorizedConnectApp(params *ListAuthorizedConnectAppPa
 
 // Lists AuthorizedConnectApp records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListAuthorizedConnectApp(params *ListAuthorizedConnectAppParams) ([]ApiV2010AuthorizedConnectApp, error) {
-	response, err := c.StreamAuthorizedConnectApp(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamAuthorizedConnectApp(params)
 
 	records := make([]ApiV2010AuthorizedConnectApp, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams AuthorizedConnectApp records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamAuthorizedConnectApp(params *ListAuthorizedConnectAppParams) (chan ApiV2010AuthorizedConnectApp, error) {
+func (c *ApiService) StreamAuthorizedConnectApp(params *ListAuthorizedConnectAppParams) (chan ApiV2010AuthorizedConnectApp, chan error) {
 	if params == nil {
 		params = &ListAuthorizedConnectAppParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010AuthorizedConnectApp, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageAuthorizedConnectApp(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamAuthorizedConnectApp(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamAuthorizedConnectApp(response *ListAuthorizedConnectAppResponse, params *ListAuthorizedConnectAppParams, recordChannel chan ApiV2010AuthorizedConnectApp, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010AuthorizedConnectApp, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.AuthorizedConnectApps
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListAuthorizedConnectAppResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.AuthorizedConnectApps
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListAuthorizedConnectAppResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListAuthorizedConnectAppResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListAuthorizedConnectAppResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListAuthorizedConnectAppResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_available_phone_numbers.go
+++ b/rest/api/v2010/accounts_available_phone_numbers.go
@@ -122,60 +122,70 @@ func (c *ApiService) PageAvailablePhoneNumberCountry(params *ListAvailablePhoneN
 
 // Lists AvailablePhoneNumberCountry records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListAvailablePhoneNumberCountry(params *ListAvailablePhoneNumberCountryParams) ([]ApiV2010AvailablePhoneNumberCountry, error) {
-	response, err := c.StreamAvailablePhoneNumberCountry(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamAvailablePhoneNumberCountry(params)
 
 	records := make([]ApiV2010AvailablePhoneNumberCountry, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams AvailablePhoneNumberCountry records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamAvailablePhoneNumberCountry(params *ListAvailablePhoneNumberCountryParams) (chan ApiV2010AvailablePhoneNumberCountry, error) {
+func (c *ApiService) StreamAvailablePhoneNumberCountry(params *ListAvailablePhoneNumberCountryParams) (chan ApiV2010AvailablePhoneNumberCountry, chan error) {
 	if params == nil {
 		params = &ListAvailablePhoneNumberCountryParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010AvailablePhoneNumberCountry, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageAvailablePhoneNumberCountry(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamAvailablePhoneNumberCountry(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamAvailablePhoneNumberCountry(response *ListAvailablePhoneNumberCountryResponse, params *ListAvailablePhoneNumberCountryParams, recordChannel chan ApiV2010AvailablePhoneNumberCountry, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010AvailablePhoneNumberCountry, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Countries
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListAvailablePhoneNumberCountryResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Countries
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListAvailablePhoneNumberCountryResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListAvailablePhoneNumberCountryResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListAvailablePhoneNumberCountryResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListAvailablePhoneNumberCountryResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_available_phone_numbers_local.go
+++ b/rest/api/v2010/accounts_available_phone_numbers_local.go
@@ -247,60 +247,70 @@ func (c *ApiService) PageAvailablePhoneNumberLocal(CountryCode string, params *L
 
 // Lists AvailablePhoneNumberLocal records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListAvailablePhoneNumberLocal(CountryCode string, params *ListAvailablePhoneNumberLocalParams) ([]ApiV2010AvailablePhoneNumberLocal, error) {
-	response, err := c.StreamAvailablePhoneNumberLocal(CountryCode, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamAvailablePhoneNumberLocal(CountryCode, params)
 
 	records := make([]ApiV2010AvailablePhoneNumberLocal, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams AvailablePhoneNumberLocal records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamAvailablePhoneNumberLocal(CountryCode string, params *ListAvailablePhoneNumberLocalParams) (chan ApiV2010AvailablePhoneNumberLocal, error) {
+func (c *ApiService) StreamAvailablePhoneNumberLocal(CountryCode string, params *ListAvailablePhoneNumberLocalParams) (chan ApiV2010AvailablePhoneNumberLocal, chan error) {
 	if params == nil {
 		params = &ListAvailablePhoneNumberLocalParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010AvailablePhoneNumberLocal, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageAvailablePhoneNumberLocal(CountryCode, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamAvailablePhoneNumberLocal(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamAvailablePhoneNumberLocal(response *ListAvailablePhoneNumberLocalResponse, params *ListAvailablePhoneNumberLocalParams, recordChannel chan ApiV2010AvailablePhoneNumberLocal, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010AvailablePhoneNumberLocal, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.AvailablePhoneNumbers
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListAvailablePhoneNumberLocalResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.AvailablePhoneNumbers
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListAvailablePhoneNumberLocalResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListAvailablePhoneNumberLocalResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListAvailablePhoneNumberLocalResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListAvailablePhoneNumberLocalResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_available_phone_numbers_machine_to_machine.go
+++ b/rest/api/v2010/accounts_available_phone_numbers_machine_to_machine.go
@@ -247,60 +247,70 @@ func (c *ApiService) PageAvailablePhoneNumberMachineToMachine(CountryCode string
 
 // Lists AvailablePhoneNumberMachineToMachine records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListAvailablePhoneNumberMachineToMachine(CountryCode string, params *ListAvailablePhoneNumberMachineToMachineParams) ([]ApiV2010AvailablePhoneNumberMachineToMachine, error) {
-	response, err := c.StreamAvailablePhoneNumberMachineToMachine(CountryCode, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamAvailablePhoneNumberMachineToMachine(CountryCode, params)
 
 	records := make([]ApiV2010AvailablePhoneNumberMachineToMachine, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams AvailablePhoneNumberMachineToMachine records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamAvailablePhoneNumberMachineToMachine(CountryCode string, params *ListAvailablePhoneNumberMachineToMachineParams) (chan ApiV2010AvailablePhoneNumberMachineToMachine, error) {
+func (c *ApiService) StreamAvailablePhoneNumberMachineToMachine(CountryCode string, params *ListAvailablePhoneNumberMachineToMachineParams) (chan ApiV2010AvailablePhoneNumberMachineToMachine, chan error) {
 	if params == nil {
 		params = &ListAvailablePhoneNumberMachineToMachineParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010AvailablePhoneNumberMachineToMachine, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageAvailablePhoneNumberMachineToMachine(CountryCode, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamAvailablePhoneNumberMachineToMachine(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamAvailablePhoneNumberMachineToMachine(response *ListAvailablePhoneNumberMachineToMachineResponse, params *ListAvailablePhoneNumberMachineToMachineParams, recordChannel chan ApiV2010AvailablePhoneNumberMachineToMachine, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010AvailablePhoneNumberMachineToMachine, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.AvailablePhoneNumbers
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListAvailablePhoneNumberMachineToMachineResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.AvailablePhoneNumbers
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListAvailablePhoneNumberMachineToMachineResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListAvailablePhoneNumberMachineToMachineResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListAvailablePhoneNumberMachineToMachineResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListAvailablePhoneNumberMachineToMachineResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_available_phone_numbers_mobile.go
+++ b/rest/api/v2010/accounts_available_phone_numbers_mobile.go
@@ -247,60 +247,70 @@ func (c *ApiService) PageAvailablePhoneNumberMobile(CountryCode string, params *
 
 // Lists AvailablePhoneNumberMobile records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListAvailablePhoneNumberMobile(CountryCode string, params *ListAvailablePhoneNumberMobileParams) ([]ApiV2010AvailablePhoneNumberMobile, error) {
-	response, err := c.StreamAvailablePhoneNumberMobile(CountryCode, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamAvailablePhoneNumberMobile(CountryCode, params)
 
 	records := make([]ApiV2010AvailablePhoneNumberMobile, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams AvailablePhoneNumberMobile records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamAvailablePhoneNumberMobile(CountryCode string, params *ListAvailablePhoneNumberMobileParams) (chan ApiV2010AvailablePhoneNumberMobile, error) {
+func (c *ApiService) StreamAvailablePhoneNumberMobile(CountryCode string, params *ListAvailablePhoneNumberMobileParams) (chan ApiV2010AvailablePhoneNumberMobile, chan error) {
 	if params == nil {
 		params = &ListAvailablePhoneNumberMobileParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010AvailablePhoneNumberMobile, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageAvailablePhoneNumberMobile(CountryCode, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamAvailablePhoneNumberMobile(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamAvailablePhoneNumberMobile(response *ListAvailablePhoneNumberMobileResponse, params *ListAvailablePhoneNumberMobileParams, recordChannel chan ApiV2010AvailablePhoneNumberMobile, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010AvailablePhoneNumberMobile, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.AvailablePhoneNumbers
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListAvailablePhoneNumberMobileResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.AvailablePhoneNumbers
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListAvailablePhoneNumberMobileResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListAvailablePhoneNumberMobileResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListAvailablePhoneNumberMobileResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListAvailablePhoneNumberMobileResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_available_phone_numbers_shared_cost.go
+++ b/rest/api/v2010/accounts_available_phone_numbers_shared_cost.go
@@ -247,60 +247,70 @@ func (c *ApiService) PageAvailablePhoneNumberSharedCost(CountryCode string, para
 
 // Lists AvailablePhoneNumberSharedCost records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListAvailablePhoneNumberSharedCost(CountryCode string, params *ListAvailablePhoneNumberSharedCostParams) ([]ApiV2010AvailablePhoneNumberSharedCost, error) {
-	response, err := c.StreamAvailablePhoneNumberSharedCost(CountryCode, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamAvailablePhoneNumberSharedCost(CountryCode, params)
 
 	records := make([]ApiV2010AvailablePhoneNumberSharedCost, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams AvailablePhoneNumberSharedCost records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamAvailablePhoneNumberSharedCost(CountryCode string, params *ListAvailablePhoneNumberSharedCostParams) (chan ApiV2010AvailablePhoneNumberSharedCost, error) {
+func (c *ApiService) StreamAvailablePhoneNumberSharedCost(CountryCode string, params *ListAvailablePhoneNumberSharedCostParams) (chan ApiV2010AvailablePhoneNumberSharedCost, chan error) {
 	if params == nil {
 		params = &ListAvailablePhoneNumberSharedCostParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010AvailablePhoneNumberSharedCost, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageAvailablePhoneNumberSharedCost(CountryCode, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamAvailablePhoneNumberSharedCost(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamAvailablePhoneNumberSharedCost(response *ListAvailablePhoneNumberSharedCostResponse, params *ListAvailablePhoneNumberSharedCostParams, recordChannel chan ApiV2010AvailablePhoneNumberSharedCost, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010AvailablePhoneNumberSharedCost, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.AvailablePhoneNumbers
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListAvailablePhoneNumberSharedCostResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.AvailablePhoneNumbers
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListAvailablePhoneNumberSharedCostResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListAvailablePhoneNumberSharedCostResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListAvailablePhoneNumberSharedCostResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListAvailablePhoneNumberSharedCostResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_available_phone_numbers_voip.go
+++ b/rest/api/v2010/accounts_available_phone_numbers_voip.go
@@ -247,60 +247,70 @@ func (c *ApiService) PageAvailablePhoneNumberVoip(CountryCode string, params *Li
 
 // Lists AvailablePhoneNumberVoip records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListAvailablePhoneNumberVoip(CountryCode string, params *ListAvailablePhoneNumberVoipParams) ([]ApiV2010AvailablePhoneNumberVoip, error) {
-	response, err := c.StreamAvailablePhoneNumberVoip(CountryCode, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamAvailablePhoneNumberVoip(CountryCode, params)
 
 	records := make([]ApiV2010AvailablePhoneNumberVoip, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams AvailablePhoneNumberVoip records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamAvailablePhoneNumberVoip(CountryCode string, params *ListAvailablePhoneNumberVoipParams) (chan ApiV2010AvailablePhoneNumberVoip, error) {
+func (c *ApiService) StreamAvailablePhoneNumberVoip(CountryCode string, params *ListAvailablePhoneNumberVoipParams) (chan ApiV2010AvailablePhoneNumberVoip, chan error) {
 	if params == nil {
 		params = &ListAvailablePhoneNumberVoipParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010AvailablePhoneNumberVoip, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageAvailablePhoneNumberVoip(CountryCode, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamAvailablePhoneNumberVoip(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamAvailablePhoneNumberVoip(response *ListAvailablePhoneNumberVoipResponse, params *ListAvailablePhoneNumberVoipParams, recordChannel chan ApiV2010AvailablePhoneNumberVoip, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010AvailablePhoneNumberVoip, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.AvailablePhoneNumbers
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListAvailablePhoneNumberVoipResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.AvailablePhoneNumbers
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListAvailablePhoneNumberVoipResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListAvailablePhoneNumberVoipResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListAvailablePhoneNumberVoipResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListAvailablePhoneNumberVoipResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_calls.go
+++ b/rest/api/v2010/accounts_calls.go
@@ -606,60 +606,70 @@ func (c *ApiService) PageCall(params *ListCallParams, pageToken, pageNumber stri
 
 // Lists Call records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCall(params *ListCallParams) ([]ApiV2010Call, error) {
-	response, err := c.StreamCall(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamCall(params)
 
 	records := make([]ApiV2010Call, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Call records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamCall(params *ListCallParams) (chan ApiV2010Call, error) {
+func (c *ApiService) StreamCall(params *ListCallParams) (chan ApiV2010Call, chan error) {
 	if params == nil {
 		params = &ListCallParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010Call, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageCall(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamCall(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamCall(response *ListCallResponse, params *ListCallParams, recordChannel chan ApiV2010Call, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010Call, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Calls
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListCallResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Calls
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListCallResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListCallResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListCallResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListCallResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_calls_events.go
+++ b/rest/api/v2010/accounts_calls_events.go
@@ -85,60 +85,70 @@ func (c *ApiService) PageCallEvent(CallSid string, params *ListCallEventParams, 
 
 // Lists CallEvent records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCallEvent(CallSid string, params *ListCallEventParams) ([]ApiV2010CallEvent, error) {
-	response, err := c.StreamCallEvent(CallSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamCallEvent(CallSid, params)
 
 	records := make([]ApiV2010CallEvent, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams CallEvent records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamCallEvent(CallSid string, params *ListCallEventParams) (chan ApiV2010CallEvent, error) {
+func (c *ApiService) StreamCallEvent(CallSid string, params *ListCallEventParams) (chan ApiV2010CallEvent, chan error) {
 	if params == nil {
 		params = &ListCallEventParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010CallEvent, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageCallEvent(CallSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamCallEvent(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamCallEvent(response *ListCallEventResponse, params *ListCallEventParams, recordChannel chan ApiV2010CallEvent, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010CallEvent, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Events
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListCallEventResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Events
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListCallEventResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListCallEventResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListCallEventResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListCallEventResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_calls_notifications.go
+++ b/rest/api/v2010/accounts_calls_notifications.go
@@ -160,60 +160,70 @@ func (c *ApiService) PageCallNotification(CallSid string, params *ListCallNotifi
 
 // Lists CallNotification records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCallNotification(CallSid string, params *ListCallNotificationParams) ([]ApiV2010CallNotification, error) {
-	response, err := c.StreamCallNotification(CallSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamCallNotification(CallSid, params)
 
 	records := make([]ApiV2010CallNotification, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams CallNotification records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamCallNotification(CallSid string, params *ListCallNotificationParams) (chan ApiV2010CallNotification, error) {
+func (c *ApiService) StreamCallNotification(CallSid string, params *ListCallNotificationParams) (chan ApiV2010CallNotification, chan error) {
 	if params == nil {
 		params = &ListCallNotificationParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010CallNotification, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageCallNotification(CallSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamCallNotification(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamCallNotification(response *ListCallNotificationResponse, params *ListCallNotificationParams, recordChannel chan ApiV2010CallNotification, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010CallNotification, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Notifications
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListCallNotificationResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Notifications
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListCallNotificationResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListCallNotificationResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListCallNotificationResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListCallNotificationResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_calls_recordings.go
+++ b/rest/api/v2010/accounts_calls_recordings.go
@@ -283,60 +283,70 @@ func (c *ApiService) PageCallRecording(CallSid string, params *ListCallRecording
 
 // Lists CallRecording records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCallRecording(CallSid string, params *ListCallRecordingParams) ([]ApiV2010CallRecording, error) {
-	response, err := c.StreamCallRecording(CallSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamCallRecording(CallSid, params)
 
 	records := make([]ApiV2010CallRecording, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams CallRecording records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamCallRecording(CallSid string, params *ListCallRecordingParams) (chan ApiV2010CallRecording, error) {
+func (c *ApiService) StreamCallRecording(CallSid string, params *ListCallRecordingParams) (chan ApiV2010CallRecording, chan error) {
 	if params == nil {
 		params = &ListCallRecordingParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010CallRecording, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageCallRecording(CallSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamCallRecording(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamCallRecording(response *ListCallRecordingResponse, params *ListCallRecordingParams, recordChannel chan ApiV2010CallRecording, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010CallRecording, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Recordings
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListCallRecordingResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Recordings
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListCallRecordingResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListCallRecordingResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListCallRecordingResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListCallRecordingResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_conferences.go
+++ b/rest/api/v2010/accounts_conferences.go
@@ -195,60 +195,70 @@ func (c *ApiService) PageConference(params *ListConferenceParams, pageToken, pag
 
 // Lists Conference records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListConference(params *ListConferenceParams) ([]ApiV2010Conference, error) {
-	response, err := c.StreamConference(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamConference(params)
 
 	records := make([]ApiV2010Conference, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Conference records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamConference(params *ListConferenceParams) (chan ApiV2010Conference, error) {
+func (c *ApiService) StreamConference(params *ListConferenceParams) (chan ApiV2010Conference, chan error) {
 	if params == nil {
 		params = &ListConferenceParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010Conference, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageConference(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamConference(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamConference(response *ListConferenceResponse, params *ListConferenceParams, recordChannel chan ApiV2010Conference, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010Conference, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Conferences
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListConferenceResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Conferences
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListConferenceResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListConferenceResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListConferenceResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListConferenceResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_conferences_participants.go
+++ b/rest/api/v2010/accounts_conferences_participants.go
@@ -585,60 +585,70 @@ func (c *ApiService) PageParticipant(ConferenceSid string, params *ListParticipa
 
 // Lists Participant records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListParticipant(ConferenceSid string, params *ListParticipantParams) ([]ApiV2010Participant, error) {
-	response, err := c.StreamParticipant(ConferenceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamParticipant(ConferenceSid, params)
 
 	records := make([]ApiV2010Participant, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Participant records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamParticipant(ConferenceSid string, params *ListParticipantParams) (chan ApiV2010Participant, error) {
+func (c *ApiService) StreamParticipant(ConferenceSid string, params *ListParticipantParams) (chan ApiV2010Participant, chan error) {
 	if params == nil {
 		params = &ListParticipantParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010Participant, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageParticipant(ConferenceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamParticipant(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamParticipant(response *ListParticipantResponse, params *ListParticipantParams, recordChannel chan ApiV2010Participant, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010Participant, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Participants
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListParticipantResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Participants
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListParticipantResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListParticipantResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListParticipantResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListParticipantResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_connect_apps.go
+++ b/rest/api/v2010/accounts_connect_apps.go
@@ -157,60 +157,70 @@ func (c *ApiService) PageConnectApp(params *ListConnectAppParams, pageToken, pag
 
 // Lists ConnectApp records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListConnectApp(params *ListConnectAppParams) ([]ApiV2010ConnectApp, error) {
-	response, err := c.StreamConnectApp(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamConnectApp(params)
 
 	records := make([]ApiV2010ConnectApp, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ConnectApp records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamConnectApp(params *ListConnectAppParams) (chan ApiV2010ConnectApp, error) {
+func (c *ApiService) StreamConnectApp(params *ListConnectAppParams) (chan ApiV2010ConnectApp, chan error) {
 	if params == nil {
 		params = &ListConnectAppParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010ConnectApp, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageConnectApp(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamConnectApp(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamConnectApp(response *ListConnectAppResponse, params *ListConnectAppParams, recordChannel chan ApiV2010ConnectApp, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010ConnectApp, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.ConnectApps
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListConnectAppResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.ConnectApps
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListConnectAppResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListConnectAppResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListConnectAppResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListConnectAppResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_incoming_phone_numbers.go
+++ b/rest/api/v2010/accounts_incoming_phone_numbers.go
@@ -448,60 +448,70 @@ func (c *ApiService) PageIncomingPhoneNumber(params *ListIncomingPhoneNumberPara
 
 // Lists IncomingPhoneNumber records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListIncomingPhoneNumber(params *ListIncomingPhoneNumberParams) ([]ApiV2010IncomingPhoneNumber, error) {
-	response, err := c.StreamIncomingPhoneNumber(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamIncomingPhoneNumber(params)
 
 	records := make([]ApiV2010IncomingPhoneNumber, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams IncomingPhoneNumber records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamIncomingPhoneNumber(params *ListIncomingPhoneNumberParams) (chan ApiV2010IncomingPhoneNumber, error) {
+func (c *ApiService) StreamIncomingPhoneNumber(params *ListIncomingPhoneNumberParams) (chan ApiV2010IncomingPhoneNumber, chan error) {
 	if params == nil {
 		params = &ListIncomingPhoneNumberParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010IncomingPhoneNumber, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageIncomingPhoneNumber(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamIncomingPhoneNumber(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamIncomingPhoneNumber(response *ListIncomingPhoneNumberResponse, params *ListIncomingPhoneNumberParams, recordChannel chan ApiV2010IncomingPhoneNumber, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010IncomingPhoneNumber, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.IncomingPhoneNumbers
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListIncomingPhoneNumberResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.IncomingPhoneNumbers
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListIncomingPhoneNumberResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListIncomingPhoneNumberResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListIncomingPhoneNumberResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListIncomingPhoneNumberResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_incoming_phone_numbers_mobile.go
+++ b/rest/api/v2010/accounts_incoming_phone_numbers_mobile.go
@@ -365,60 +365,70 @@ func (c *ApiService) PageIncomingPhoneNumberMobile(params *ListIncomingPhoneNumb
 
 // Lists IncomingPhoneNumberMobile records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListIncomingPhoneNumberMobile(params *ListIncomingPhoneNumberMobileParams) ([]ApiV2010IncomingPhoneNumberMobile, error) {
-	response, err := c.StreamIncomingPhoneNumberMobile(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamIncomingPhoneNumberMobile(params)
 
 	records := make([]ApiV2010IncomingPhoneNumberMobile, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams IncomingPhoneNumberMobile records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamIncomingPhoneNumberMobile(params *ListIncomingPhoneNumberMobileParams) (chan ApiV2010IncomingPhoneNumberMobile, error) {
+func (c *ApiService) StreamIncomingPhoneNumberMobile(params *ListIncomingPhoneNumberMobileParams) (chan ApiV2010IncomingPhoneNumberMobile, chan error) {
 	if params == nil {
 		params = &ListIncomingPhoneNumberMobileParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010IncomingPhoneNumberMobile, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageIncomingPhoneNumberMobile(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamIncomingPhoneNumberMobile(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamIncomingPhoneNumberMobile(response *ListIncomingPhoneNumberMobileResponse, params *ListIncomingPhoneNumberMobileParams, recordChannel chan ApiV2010IncomingPhoneNumberMobile, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010IncomingPhoneNumberMobile, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.IncomingPhoneNumbers
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListIncomingPhoneNumberMobileResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.IncomingPhoneNumbers
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListIncomingPhoneNumberMobileResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListIncomingPhoneNumberMobileResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListIncomingPhoneNumberMobileResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListIncomingPhoneNumberMobileResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_incoming_phone_numbers_toll_free.go
+++ b/rest/api/v2010/accounts_incoming_phone_numbers_toll_free.go
@@ -365,60 +365,70 @@ func (c *ApiService) PageIncomingPhoneNumberTollFree(params *ListIncomingPhoneNu
 
 // Lists IncomingPhoneNumberTollFree records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListIncomingPhoneNumberTollFree(params *ListIncomingPhoneNumberTollFreeParams) ([]ApiV2010IncomingPhoneNumberTollFree, error) {
-	response, err := c.StreamIncomingPhoneNumberTollFree(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamIncomingPhoneNumberTollFree(params)
 
 	records := make([]ApiV2010IncomingPhoneNumberTollFree, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams IncomingPhoneNumberTollFree records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamIncomingPhoneNumberTollFree(params *ListIncomingPhoneNumberTollFreeParams) (chan ApiV2010IncomingPhoneNumberTollFree, error) {
+func (c *ApiService) StreamIncomingPhoneNumberTollFree(params *ListIncomingPhoneNumberTollFreeParams) (chan ApiV2010IncomingPhoneNumberTollFree, chan error) {
 	if params == nil {
 		params = &ListIncomingPhoneNumberTollFreeParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010IncomingPhoneNumberTollFree, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageIncomingPhoneNumberTollFree(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamIncomingPhoneNumberTollFree(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamIncomingPhoneNumberTollFree(response *ListIncomingPhoneNumberTollFreeResponse, params *ListIncomingPhoneNumberTollFreeParams, recordChannel chan ApiV2010IncomingPhoneNumberTollFree, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010IncomingPhoneNumberTollFree, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.IncomingPhoneNumbers
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListIncomingPhoneNumberTollFreeResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.IncomingPhoneNumbers
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListIncomingPhoneNumberTollFreeResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListIncomingPhoneNumberTollFreeResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListIncomingPhoneNumberTollFreeResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListIncomingPhoneNumberTollFreeResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_messages.go
+++ b/rest/api/v2010/accounts_messages.go
@@ -417,60 +417,70 @@ func (c *ApiService) PageMessage(params *ListMessageParams, pageToken, pageNumbe
 
 // Lists Message records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMessage(params *ListMessageParams) ([]ApiV2010Message, error) {
-	response, err := c.StreamMessage(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamMessage(params)
 
 	records := make([]ApiV2010Message, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Message records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamMessage(params *ListMessageParams) (chan ApiV2010Message, error) {
+func (c *ApiService) StreamMessage(params *ListMessageParams) (chan ApiV2010Message, chan error) {
 	if params == nil {
 		params = &ListMessageParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010Message, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageMessage(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamMessage(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamMessage(response *ListMessageResponse, params *ListMessageParams, recordChannel chan ApiV2010Message, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010Message, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Messages
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListMessageResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Messages
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListMessageResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListMessageResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListMessageResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListMessageResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_messages_media.go
+++ b/rest/api/v2010/accounts_messages_media.go
@@ -188,60 +188,70 @@ func (c *ApiService) PageMedia(MessageSid string, params *ListMediaParams, pageT
 
 // Lists Media records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMedia(MessageSid string, params *ListMediaParams) ([]ApiV2010Media, error) {
-	response, err := c.StreamMedia(MessageSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamMedia(MessageSid, params)
 
 	records := make([]ApiV2010Media, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Media records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamMedia(MessageSid string, params *ListMediaParams) (chan ApiV2010Media, error) {
+func (c *ApiService) StreamMedia(MessageSid string, params *ListMediaParams) (chan ApiV2010Media, chan error) {
 	if params == nil {
 		params = &ListMediaParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010Media, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageMedia(MessageSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamMedia(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamMedia(response *ListMediaResponse, params *ListMediaParams, recordChannel chan ApiV2010Media, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010Media, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.MediaList
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListMediaResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.MediaList
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListMediaResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListMediaResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListMediaResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListMediaResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_notifications.go
+++ b/rest/api/v2010/accounts_notifications.go
@@ -159,60 +159,70 @@ func (c *ApiService) PageNotification(params *ListNotificationParams, pageToken,
 
 // Lists Notification records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListNotification(params *ListNotificationParams) ([]ApiV2010Notification, error) {
-	response, err := c.StreamNotification(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamNotification(params)
 
 	records := make([]ApiV2010Notification, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Notification records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamNotification(params *ListNotificationParams) (chan ApiV2010Notification, error) {
+func (c *ApiService) StreamNotification(params *ListNotificationParams) (chan ApiV2010Notification, chan error) {
 	if params == nil {
 		params = &ListNotificationParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010Notification, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageNotification(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamNotification(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamNotification(response *ListNotificationResponse, params *ListNotificationParams, recordChannel chan ApiV2010Notification, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010Notification, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Notifications
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListNotificationResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Notifications
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListNotificationResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListNotificationResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListNotificationResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListNotificationResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_outgoing_caller_ids.go
+++ b/rest/api/v2010/accounts_outgoing_caller_ids.go
@@ -267,60 +267,70 @@ func (c *ApiService) PageOutgoingCallerId(params *ListOutgoingCallerIdParams, pa
 
 // Lists OutgoingCallerId records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListOutgoingCallerId(params *ListOutgoingCallerIdParams) ([]ApiV2010OutgoingCallerId, error) {
-	response, err := c.StreamOutgoingCallerId(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamOutgoingCallerId(params)
 
 	records := make([]ApiV2010OutgoingCallerId, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams OutgoingCallerId records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamOutgoingCallerId(params *ListOutgoingCallerIdParams) (chan ApiV2010OutgoingCallerId, error) {
+func (c *ApiService) StreamOutgoingCallerId(params *ListOutgoingCallerIdParams) (chan ApiV2010OutgoingCallerId, chan error) {
 	if params == nil {
 		params = &ListOutgoingCallerIdParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010OutgoingCallerId, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageOutgoingCallerId(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamOutgoingCallerId(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamOutgoingCallerId(response *ListOutgoingCallerIdResponse, params *ListOutgoingCallerIdParams, recordChannel chan ApiV2010OutgoingCallerId, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010OutgoingCallerId, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.OutgoingCallerIds
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListOutgoingCallerIdResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.OutgoingCallerIds
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListOutgoingCallerIdResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListOutgoingCallerIdResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListOutgoingCallerIdResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListOutgoingCallerIdResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_queues_members.go
+++ b/rest/api/v2010/accounts_queues_members.go
@@ -125,60 +125,70 @@ func (c *ApiService) PageMember(QueueSid string, params *ListMemberParams, pageT
 
 // Lists Member records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMember(QueueSid string, params *ListMemberParams) ([]ApiV2010Member, error) {
-	response, err := c.StreamMember(QueueSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamMember(QueueSid, params)
 
 	records := make([]ApiV2010Member, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Member records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamMember(QueueSid string, params *ListMemberParams) (chan ApiV2010Member, error) {
+func (c *ApiService) StreamMember(QueueSid string, params *ListMemberParams) (chan ApiV2010Member, chan error) {
 	if params == nil {
 		params = &ListMemberParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010Member, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageMember(QueueSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamMember(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamMember(response *ListMemberResponse, params *ListMemberParams, recordChannel chan ApiV2010Member, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010Member, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.QueueMembers
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListMemberResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.QueueMembers
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListMemberResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListMemberResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListMemberResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListMemberResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_recordings.go
+++ b/rest/api/v2010/accounts_recordings.go
@@ -222,60 +222,70 @@ func (c *ApiService) PageRecording(params *ListRecordingParams, pageToken, pageN
 
 // Lists Recording records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRecording(params *ListRecordingParams) ([]ApiV2010Recording, error) {
-	response, err := c.StreamRecording(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamRecording(params)
 
 	records := make([]ApiV2010Recording, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Recording records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamRecording(params *ListRecordingParams) (chan ApiV2010Recording, error) {
+func (c *ApiService) StreamRecording(params *ListRecordingParams) (chan ApiV2010Recording, chan error) {
 	if params == nil {
 		params = &ListRecordingParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010Recording, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageRecording(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamRecording(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamRecording(response *ListRecordingResponse, params *ListRecordingParams, recordChannel chan ApiV2010Recording, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010Recording, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Recordings
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListRecordingResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Recordings
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListRecordingResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListRecordingResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListRecordingResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListRecordingResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_recordings_add_on_results.go
+++ b/rest/api/v2010/accounts_recordings_add_on_results.go
@@ -160,60 +160,70 @@ func (c *ApiService) PageRecordingAddOnResult(ReferenceSid string, params *ListR
 
 // Lists RecordingAddOnResult records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRecordingAddOnResult(ReferenceSid string, params *ListRecordingAddOnResultParams) ([]ApiV2010RecordingAddOnResult, error) {
-	response, err := c.StreamRecordingAddOnResult(ReferenceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamRecordingAddOnResult(ReferenceSid, params)
 
 	records := make([]ApiV2010RecordingAddOnResult, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams RecordingAddOnResult records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamRecordingAddOnResult(ReferenceSid string, params *ListRecordingAddOnResultParams) (chan ApiV2010RecordingAddOnResult, error) {
+func (c *ApiService) StreamRecordingAddOnResult(ReferenceSid string, params *ListRecordingAddOnResultParams) (chan ApiV2010RecordingAddOnResult, chan error) {
 	if params == nil {
 		params = &ListRecordingAddOnResultParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010RecordingAddOnResult, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageRecordingAddOnResult(ReferenceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamRecordingAddOnResult(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamRecordingAddOnResult(response *ListRecordingAddOnResultResponse, params *ListRecordingAddOnResultParams, recordChannel chan ApiV2010RecordingAddOnResult, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010RecordingAddOnResult, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.AddOnResults
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListRecordingAddOnResultResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.AddOnResults
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListRecordingAddOnResultResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListRecordingAddOnResultResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListRecordingAddOnResultResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListRecordingAddOnResultResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_recordings_add_on_results_payloads.go
+++ b/rest/api/v2010/accounts_recordings_add_on_results_payloads.go
@@ -163,60 +163,70 @@ func (c *ApiService) PageRecordingAddOnResultPayload(ReferenceSid string, AddOnR
 
 // Lists RecordingAddOnResultPayload records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRecordingAddOnResultPayload(ReferenceSid string, AddOnResultSid string, params *ListRecordingAddOnResultPayloadParams) ([]ApiV2010RecordingAddOnResultPayload, error) {
-	response, err := c.StreamRecordingAddOnResultPayload(ReferenceSid, AddOnResultSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamRecordingAddOnResultPayload(ReferenceSid, AddOnResultSid, params)
 
 	records := make([]ApiV2010RecordingAddOnResultPayload, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams RecordingAddOnResultPayload records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamRecordingAddOnResultPayload(ReferenceSid string, AddOnResultSid string, params *ListRecordingAddOnResultPayloadParams) (chan ApiV2010RecordingAddOnResultPayload, error) {
+func (c *ApiService) StreamRecordingAddOnResultPayload(ReferenceSid string, AddOnResultSid string, params *ListRecordingAddOnResultPayloadParams) (chan ApiV2010RecordingAddOnResultPayload, chan error) {
 	if params == nil {
 		params = &ListRecordingAddOnResultPayloadParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010RecordingAddOnResultPayload, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageRecordingAddOnResultPayload(ReferenceSid, AddOnResultSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamRecordingAddOnResultPayload(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamRecordingAddOnResultPayload(response *ListRecordingAddOnResultPayloadResponse, params *ListRecordingAddOnResultPayloadParams, recordChannel chan ApiV2010RecordingAddOnResultPayload, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010RecordingAddOnResultPayload, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Payloads
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListRecordingAddOnResultPayloadResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Payloads
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListRecordingAddOnResultPayloadResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListRecordingAddOnResultPayloadResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListRecordingAddOnResultPayloadResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListRecordingAddOnResultPayloadResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_recordings_transcriptions.go
+++ b/rest/api/v2010/accounts_recordings_transcriptions.go
@@ -158,60 +158,70 @@ func (c *ApiService) PageRecordingTranscription(RecordingSid string, params *Lis
 
 // Lists RecordingTranscription records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRecordingTranscription(RecordingSid string, params *ListRecordingTranscriptionParams) ([]ApiV2010RecordingTranscription, error) {
-	response, err := c.StreamRecordingTranscription(RecordingSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamRecordingTranscription(RecordingSid, params)
 
 	records := make([]ApiV2010RecordingTranscription, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams RecordingTranscription records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamRecordingTranscription(RecordingSid string, params *ListRecordingTranscriptionParams) (chan ApiV2010RecordingTranscription, error) {
+func (c *ApiService) StreamRecordingTranscription(RecordingSid string, params *ListRecordingTranscriptionParams) (chan ApiV2010RecordingTranscription, chan error) {
 	if params == nil {
 		params = &ListRecordingTranscriptionParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010RecordingTranscription, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageRecordingTranscription(RecordingSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamRecordingTranscription(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamRecordingTranscription(response *ListRecordingTranscriptionResponse, params *ListRecordingTranscriptionParams, recordChannel chan ApiV2010RecordingTranscription, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010RecordingTranscription, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Transcriptions
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListRecordingTranscriptionResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Transcriptions
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListRecordingTranscriptionResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListRecordingTranscriptionResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListRecordingTranscriptionResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListRecordingTranscriptionResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_signing_keys.go
+++ b/rest/api/v2010/accounts_signing_keys.go
@@ -203,60 +203,70 @@ func (c *ApiService) PageSigningKey(params *ListSigningKeyParams, pageToken, pag
 
 // Lists SigningKey records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSigningKey(params *ListSigningKeyParams) ([]ApiV2010SigningKey, error) {
-	response, err := c.StreamSigningKey(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamSigningKey(params)
 
 	records := make([]ApiV2010SigningKey, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams SigningKey records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamSigningKey(params *ListSigningKeyParams) (chan ApiV2010SigningKey, error) {
+func (c *ApiService) StreamSigningKey(params *ListSigningKeyParams) (chan ApiV2010SigningKey, chan error) {
 	if params == nil {
 		params = &ListSigningKeyParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010SigningKey, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageSigningKey(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamSigningKey(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamSigningKey(response *ListSigningKeyResponse, params *ListSigningKeyParams, recordChannel chan ApiV2010SigningKey, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010SigningKey, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.SigningKeys
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListSigningKeyResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.SigningKeys
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListSigningKeyResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListSigningKeyResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListSigningKeyResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListSigningKeyResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_sip_credential_lists.go
+++ b/rest/api/v2010/accounts_sip_credential_lists.go
@@ -205,60 +205,70 @@ func (c *ApiService) PageSipCredentialList(params *ListSipCredentialListParams, 
 
 // Lists SipCredentialList records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSipCredentialList(params *ListSipCredentialListParams) ([]ApiV2010SipCredentialList, error) {
-	response, err := c.StreamSipCredentialList(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamSipCredentialList(params)
 
 	records := make([]ApiV2010SipCredentialList, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams SipCredentialList records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamSipCredentialList(params *ListSipCredentialListParams) (chan ApiV2010SipCredentialList, error) {
+func (c *ApiService) StreamSipCredentialList(params *ListSipCredentialListParams) (chan ApiV2010SipCredentialList, chan error) {
 	if params == nil {
 		params = &ListSipCredentialListParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010SipCredentialList, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageSipCredentialList(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamSipCredentialList(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamSipCredentialList(response *ListSipCredentialListResponse, params *ListSipCredentialListParams, recordChannel chan ApiV2010SipCredentialList, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010SipCredentialList, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.CredentialLists
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListSipCredentialListResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.CredentialLists
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListSipCredentialListResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListSipCredentialListResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListSipCredentialListResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListSipCredentialListResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_sip_credential_lists_credentials.go
+++ b/rest/api/v2010/accounts_sip_credential_lists_credentials.go
@@ -218,60 +218,70 @@ func (c *ApiService) PageSipCredential(CredentialListSid string, params *ListSip
 
 // Lists SipCredential records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSipCredential(CredentialListSid string, params *ListSipCredentialParams) ([]ApiV2010SipCredential, error) {
-	response, err := c.StreamSipCredential(CredentialListSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamSipCredential(CredentialListSid, params)
 
 	records := make([]ApiV2010SipCredential, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams SipCredential records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamSipCredential(CredentialListSid string, params *ListSipCredentialParams) (chan ApiV2010SipCredential, error) {
+func (c *ApiService) StreamSipCredential(CredentialListSid string, params *ListSipCredentialParams) (chan ApiV2010SipCredential, chan error) {
 	if params == nil {
 		params = &ListSipCredentialParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010SipCredential, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageSipCredential(CredentialListSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamSipCredential(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamSipCredential(response *ListSipCredentialResponse, params *ListSipCredentialParams, recordChannel chan ApiV2010SipCredential, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010SipCredential, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Credentials
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListSipCredentialResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Credentials
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListSipCredentialResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListSipCredentialResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListSipCredentialResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListSipCredentialResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_sip_domains.go
+++ b/rest/api/v2010/accounts_sip_domains.go
@@ -313,60 +313,70 @@ func (c *ApiService) PageSipDomain(params *ListSipDomainParams, pageToken, pageN
 
 // Lists SipDomain records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSipDomain(params *ListSipDomainParams) ([]ApiV2010SipDomain, error) {
-	response, err := c.StreamSipDomain(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamSipDomain(params)
 
 	records := make([]ApiV2010SipDomain, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams SipDomain records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamSipDomain(params *ListSipDomainParams) (chan ApiV2010SipDomain, error) {
+func (c *ApiService) StreamSipDomain(params *ListSipDomainParams) (chan ApiV2010SipDomain, chan error) {
 	if params == nil {
 		params = &ListSipDomainParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010SipDomain, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageSipDomain(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamSipDomain(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamSipDomain(response *ListSipDomainResponse, params *ListSipDomainParams, recordChannel chan ApiV2010SipDomain, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010SipDomain, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Domains
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListSipDomainResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Domains
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListSipDomainResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListSipDomainResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListSipDomainResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListSipDomainResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_sip_domains_auth_calls_ip_access_control_list_mappings.go
+++ b/rest/api/v2010/accounts_sip_domains_auth_calls_ip_access_control_list_mappings.go
@@ -209,60 +209,70 @@ func (c *ApiService) PageSipAuthCallsIpAccessControlListMapping(DomainSid string
 
 // Lists SipAuthCallsIpAccessControlListMapping records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSipAuthCallsIpAccessControlListMapping(DomainSid string, params *ListSipAuthCallsIpAccessControlListMappingParams) ([]ApiV2010SipAuthCallsIpAccessControlListMapping, error) {
-	response, err := c.StreamSipAuthCallsIpAccessControlListMapping(DomainSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamSipAuthCallsIpAccessControlListMapping(DomainSid, params)
 
 	records := make([]ApiV2010SipAuthCallsIpAccessControlListMapping, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams SipAuthCallsIpAccessControlListMapping records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamSipAuthCallsIpAccessControlListMapping(DomainSid string, params *ListSipAuthCallsIpAccessControlListMappingParams) (chan ApiV2010SipAuthCallsIpAccessControlListMapping, error) {
+func (c *ApiService) StreamSipAuthCallsIpAccessControlListMapping(DomainSid string, params *ListSipAuthCallsIpAccessControlListMappingParams) (chan ApiV2010SipAuthCallsIpAccessControlListMapping, chan error) {
 	if params == nil {
 		params = &ListSipAuthCallsIpAccessControlListMappingParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010SipAuthCallsIpAccessControlListMapping, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageSipAuthCallsIpAccessControlListMapping(DomainSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamSipAuthCallsIpAccessControlListMapping(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamSipAuthCallsIpAccessControlListMapping(response *ListSipAuthCallsIpAccessControlListMappingResponse, params *ListSipAuthCallsIpAccessControlListMappingParams, recordChannel chan ApiV2010SipAuthCallsIpAccessControlListMapping, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010SipAuthCallsIpAccessControlListMapping, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Contents
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListSipAuthCallsIpAccessControlListMappingResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Contents
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListSipAuthCallsIpAccessControlListMappingResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListSipAuthCallsIpAccessControlListMappingResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListSipAuthCallsIpAccessControlListMappingResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListSipAuthCallsIpAccessControlListMappingResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_sip_domains_auth_registrations_credential_list_mappings.go
+++ b/rest/api/v2010/accounts_sip_domains_auth_registrations_credential_list_mappings.go
@@ -209,60 +209,70 @@ func (c *ApiService) PageSipAuthRegistrationsCredentialListMapping(DomainSid str
 
 // Lists SipAuthRegistrationsCredentialListMapping records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSipAuthRegistrationsCredentialListMapping(DomainSid string, params *ListSipAuthRegistrationsCredentialListMappingParams) ([]ApiV2010SipAuthRegistrationsCredentialListMapping, error) {
-	response, err := c.StreamSipAuthRegistrationsCredentialListMapping(DomainSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamSipAuthRegistrationsCredentialListMapping(DomainSid, params)
 
 	records := make([]ApiV2010SipAuthRegistrationsCredentialListMapping, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams SipAuthRegistrationsCredentialListMapping records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamSipAuthRegistrationsCredentialListMapping(DomainSid string, params *ListSipAuthRegistrationsCredentialListMappingParams) (chan ApiV2010SipAuthRegistrationsCredentialListMapping, error) {
+func (c *ApiService) StreamSipAuthRegistrationsCredentialListMapping(DomainSid string, params *ListSipAuthRegistrationsCredentialListMappingParams) (chan ApiV2010SipAuthRegistrationsCredentialListMapping, chan error) {
 	if params == nil {
 		params = &ListSipAuthRegistrationsCredentialListMappingParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010SipAuthRegistrationsCredentialListMapping, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageSipAuthRegistrationsCredentialListMapping(DomainSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamSipAuthRegistrationsCredentialListMapping(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamSipAuthRegistrationsCredentialListMapping(response *ListSipAuthRegistrationsCredentialListMappingResponse, params *ListSipAuthRegistrationsCredentialListMappingParams, recordChannel chan ApiV2010SipAuthRegistrationsCredentialListMapping, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010SipAuthRegistrationsCredentialListMapping, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Contents
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListSipAuthRegistrationsCredentialListMappingResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Contents
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListSipAuthRegistrationsCredentialListMappingResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListSipAuthRegistrationsCredentialListMappingResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListSipAuthRegistrationsCredentialListMappingResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListSipAuthRegistrationsCredentialListMappingResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_sip_domains_credential_list_mappings.go
+++ b/rest/api/v2010/accounts_sip_domains_credential_list_mappings.go
@@ -209,60 +209,70 @@ func (c *ApiService) PageSipCredentialListMapping(DomainSid string, params *List
 
 // Lists SipCredentialListMapping records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSipCredentialListMapping(DomainSid string, params *ListSipCredentialListMappingParams) ([]ApiV2010SipCredentialListMapping, error) {
-	response, err := c.StreamSipCredentialListMapping(DomainSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamSipCredentialListMapping(DomainSid, params)
 
 	records := make([]ApiV2010SipCredentialListMapping, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams SipCredentialListMapping records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamSipCredentialListMapping(DomainSid string, params *ListSipCredentialListMappingParams) (chan ApiV2010SipCredentialListMapping, error) {
+func (c *ApiService) StreamSipCredentialListMapping(DomainSid string, params *ListSipCredentialListMappingParams) (chan ApiV2010SipCredentialListMapping, chan error) {
 	if params == nil {
 		params = &ListSipCredentialListMappingParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010SipCredentialListMapping, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageSipCredentialListMapping(DomainSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamSipCredentialListMapping(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamSipCredentialListMapping(response *ListSipCredentialListMappingResponse, params *ListSipCredentialListMappingParams, recordChannel chan ApiV2010SipCredentialListMapping, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010SipCredentialListMapping, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.CredentialListMappings
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListSipCredentialListMappingResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.CredentialListMappings
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListSipCredentialListMappingResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListSipCredentialListMappingResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListSipCredentialListMappingResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListSipCredentialListMappingResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_sip_domains_ip_access_control_list_mappings.go
+++ b/rest/api/v2010/accounts_sip_domains_ip_access_control_list_mappings.go
@@ -209,60 +209,70 @@ func (c *ApiService) PageSipIpAccessControlListMapping(DomainSid string, params 
 
 // Lists SipIpAccessControlListMapping records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSipIpAccessControlListMapping(DomainSid string, params *ListSipIpAccessControlListMappingParams) ([]ApiV2010SipIpAccessControlListMapping, error) {
-	response, err := c.StreamSipIpAccessControlListMapping(DomainSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamSipIpAccessControlListMapping(DomainSid, params)
 
 	records := make([]ApiV2010SipIpAccessControlListMapping, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams SipIpAccessControlListMapping records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamSipIpAccessControlListMapping(DomainSid string, params *ListSipIpAccessControlListMappingParams) (chan ApiV2010SipIpAccessControlListMapping, error) {
+func (c *ApiService) StreamSipIpAccessControlListMapping(DomainSid string, params *ListSipIpAccessControlListMappingParams) (chan ApiV2010SipIpAccessControlListMapping, chan error) {
 	if params == nil {
 		params = &ListSipIpAccessControlListMappingParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010SipIpAccessControlListMapping, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageSipIpAccessControlListMapping(DomainSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamSipIpAccessControlListMapping(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamSipIpAccessControlListMapping(response *ListSipIpAccessControlListMappingResponse, params *ListSipIpAccessControlListMappingParams, recordChannel chan ApiV2010SipIpAccessControlListMapping, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010SipIpAccessControlListMapping, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.IpAccessControlListMappings
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListSipIpAccessControlListMappingResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.IpAccessControlListMappings
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListSipIpAccessControlListMappingResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListSipIpAccessControlListMappingResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListSipIpAccessControlListMappingResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListSipIpAccessControlListMappingResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_sms_short_codes.go
+++ b/rest/api/v2010/accounts_sms_short_codes.go
@@ -141,60 +141,70 @@ func (c *ApiService) PageShortCode(params *ListShortCodeParams, pageToken, pageN
 
 // Lists ShortCode records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListShortCode(params *ListShortCodeParams) ([]ApiV2010ShortCode, error) {
-	response, err := c.StreamShortCode(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamShortCode(params)
 
 	records := make([]ApiV2010ShortCode, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ShortCode records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamShortCode(params *ListShortCodeParams) (chan ApiV2010ShortCode, error) {
+func (c *ApiService) StreamShortCode(params *ListShortCodeParams) (chan ApiV2010ShortCode, chan error) {
 	if params == nil {
 		params = &ListShortCodeParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010ShortCode, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageShortCode(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamShortCode(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamShortCode(response *ListShortCodeResponse, params *ListShortCodeParams, recordChannel chan ApiV2010ShortCode, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010ShortCode, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.ShortCodes
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListShortCodeResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.ShortCodes
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListShortCodeResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListShortCodeResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListShortCodeResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListShortCodeResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_transcriptions.go
+++ b/rest/api/v2010/accounts_transcriptions.go
@@ -157,60 +157,70 @@ func (c *ApiService) PageTranscription(params *ListTranscriptionParams, pageToke
 
 // Lists Transcription records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListTranscription(params *ListTranscriptionParams) ([]ApiV2010Transcription, error) {
-	response, err := c.StreamTranscription(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamTranscription(params)
 
 	records := make([]ApiV2010Transcription, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Transcription records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamTranscription(params *ListTranscriptionParams) (chan ApiV2010Transcription, error) {
+func (c *ApiService) StreamTranscription(params *ListTranscriptionParams) (chan ApiV2010Transcription, chan error) {
 	if params == nil {
 		params = &ListTranscriptionParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010Transcription, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageTranscription(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamTranscription(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamTranscription(response *ListTranscriptionResponse, params *ListTranscriptionParams, recordChannel chan ApiV2010Transcription, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010Transcription, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Transcriptions
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListTranscriptionResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Transcriptions
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListTranscriptionResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListTranscriptionResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListTranscriptionResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListTranscriptionResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_usage_records.go
+++ b/rest/api/v2010/accounts_usage_records.go
@@ -120,60 +120,70 @@ func (c *ApiService) PageUsageRecord(params *ListUsageRecordParams, pageToken, p
 
 // Lists UsageRecord records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUsageRecord(params *ListUsageRecordParams) ([]ApiV2010UsageRecord, error) {
-	response, err := c.StreamUsageRecord(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamUsageRecord(params)
 
 	records := make([]ApiV2010UsageRecord, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams UsageRecord records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamUsageRecord(params *ListUsageRecordParams) (chan ApiV2010UsageRecord, error) {
+func (c *ApiService) StreamUsageRecord(params *ListUsageRecordParams) (chan ApiV2010UsageRecord, chan error) {
 	if params == nil {
 		params = &ListUsageRecordParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010UsageRecord, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageUsageRecord(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamUsageRecord(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamUsageRecord(response *ListUsageRecordResponse, params *ListUsageRecordParams, recordChannel chan ApiV2010UsageRecord, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010UsageRecord, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.UsageRecords
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListUsageRecordResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.UsageRecords
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListUsageRecordResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListUsageRecordResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListUsageRecordResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListUsageRecordResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_usage_records_all_time.go
+++ b/rest/api/v2010/accounts_usage_records_all_time.go
@@ -120,60 +120,70 @@ func (c *ApiService) PageUsageRecordAllTime(params *ListUsageRecordAllTimeParams
 
 // Lists UsageRecordAllTime records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUsageRecordAllTime(params *ListUsageRecordAllTimeParams) ([]ApiV2010UsageRecordAllTime, error) {
-	response, err := c.StreamUsageRecordAllTime(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamUsageRecordAllTime(params)
 
 	records := make([]ApiV2010UsageRecordAllTime, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams UsageRecordAllTime records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamUsageRecordAllTime(params *ListUsageRecordAllTimeParams) (chan ApiV2010UsageRecordAllTime, error) {
+func (c *ApiService) StreamUsageRecordAllTime(params *ListUsageRecordAllTimeParams) (chan ApiV2010UsageRecordAllTime, chan error) {
 	if params == nil {
 		params = &ListUsageRecordAllTimeParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010UsageRecordAllTime, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageUsageRecordAllTime(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamUsageRecordAllTime(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamUsageRecordAllTime(response *ListUsageRecordAllTimeResponse, params *ListUsageRecordAllTimeParams, recordChannel chan ApiV2010UsageRecordAllTime, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010UsageRecordAllTime, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.UsageRecords
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListUsageRecordAllTimeResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.UsageRecords
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListUsageRecordAllTimeResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListUsageRecordAllTimeResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListUsageRecordAllTimeResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListUsageRecordAllTimeResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_usage_records_daily.go
+++ b/rest/api/v2010/accounts_usage_records_daily.go
@@ -120,60 +120,70 @@ func (c *ApiService) PageUsageRecordDaily(params *ListUsageRecordDailyParams, pa
 
 // Lists UsageRecordDaily records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUsageRecordDaily(params *ListUsageRecordDailyParams) ([]ApiV2010UsageRecordDaily, error) {
-	response, err := c.StreamUsageRecordDaily(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamUsageRecordDaily(params)
 
 	records := make([]ApiV2010UsageRecordDaily, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams UsageRecordDaily records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamUsageRecordDaily(params *ListUsageRecordDailyParams) (chan ApiV2010UsageRecordDaily, error) {
+func (c *ApiService) StreamUsageRecordDaily(params *ListUsageRecordDailyParams) (chan ApiV2010UsageRecordDaily, chan error) {
 	if params == nil {
 		params = &ListUsageRecordDailyParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010UsageRecordDaily, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageUsageRecordDaily(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamUsageRecordDaily(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamUsageRecordDaily(response *ListUsageRecordDailyResponse, params *ListUsageRecordDailyParams, recordChannel chan ApiV2010UsageRecordDaily, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010UsageRecordDaily, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.UsageRecords
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListUsageRecordDailyResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.UsageRecords
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListUsageRecordDailyResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListUsageRecordDailyResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListUsageRecordDailyResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListUsageRecordDailyResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_usage_records_last_month.go
+++ b/rest/api/v2010/accounts_usage_records_last_month.go
@@ -120,60 +120,70 @@ func (c *ApiService) PageUsageRecordLastMonth(params *ListUsageRecordLastMonthPa
 
 // Lists UsageRecordLastMonth records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUsageRecordLastMonth(params *ListUsageRecordLastMonthParams) ([]ApiV2010UsageRecordLastMonth, error) {
-	response, err := c.StreamUsageRecordLastMonth(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamUsageRecordLastMonth(params)
 
 	records := make([]ApiV2010UsageRecordLastMonth, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams UsageRecordLastMonth records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamUsageRecordLastMonth(params *ListUsageRecordLastMonthParams) (chan ApiV2010UsageRecordLastMonth, error) {
+func (c *ApiService) StreamUsageRecordLastMonth(params *ListUsageRecordLastMonthParams) (chan ApiV2010UsageRecordLastMonth, chan error) {
 	if params == nil {
 		params = &ListUsageRecordLastMonthParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010UsageRecordLastMonth, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageUsageRecordLastMonth(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamUsageRecordLastMonth(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamUsageRecordLastMonth(response *ListUsageRecordLastMonthResponse, params *ListUsageRecordLastMonthParams, recordChannel chan ApiV2010UsageRecordLastMonth, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010UsageRecordLastMonth, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.UsageRecords
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListUsageRecordLastMonthResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.UsageRecords
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListUsageRecordLastMonthResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListUsageRecordLastMonthResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListUsageRecordLastMonthResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListUsageRecordLastMonthResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_usage_records_monthly.go
+++ b/rest/api/v2010/accounts_usage_records_monthly.go
@@ -120,60 +120,70 @@ func (c *ApiService) PageUsageRecordMonthly(params *ListUsageRecordMonthlyParams
 
 // Lists UsageRecordMonthly records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUsageRecordMonthly(params *ListUsageRecordMonthlyParams) ([]ApiV2010UsageRecordMonthly, error) {
-	response, err := c.StreamUsageRecordMonthly(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamUsageRecordMonthly(params)
 
 	records := make([]ApiV2010UsageRecordMonthly, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams UsageRecordMonthly records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamUsageRecordMonthly(params *ListUsageRecordMonthlyParams) (chan ApiV2010UsageRecordMonthly, error) {
+func (c *ApiService) StreamUsageRecordMonthly(params *ListUsageRecordMonthlyParams) (chan ApiV2010UsageRecordMonthly, chan error) {
 	if params == nil {
 		params = &ListUsageRecordMonthlyParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010UsageRecordMonthly, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageUsageRecordMonthly(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamUsageRecordMonthly(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamUsageRecordMonthly(response *ListUsageRecordMonthlyResponse, params *ListUsageRecordMonthlyParams, recordChannel chan ApiV2010UsageRecordMonthly, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010UsageRecordMonthly, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.UsageRecords
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListUsageRecordMonthlyResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.UsageRecords
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListUsageRecordMonthlyResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListUsageRecordMonthlyResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListUsageRecordMonthlyResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListUsageRecordMonthlyResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_usage_records_this_month.go
+++ b/rest/api/v2010/accounts_usage_records_this_month.go
@@ -120,60 +120,70 @@ func (c *ApiService) PageUsageRecordThisMonth(params *ListUsageRecordThisMonthPa
 
 // Lists UsageRecordThisMonth records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUsageRecordThisMonth(params *ListUsageRecordThisMonthParams) ([]ApiV2010UsageRecordThisMonth, error) {
-	response, err := c.StreamUsageRecordThisMonth(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamUsageRecordThisMonth(params)
 
 	records := make([]ApiV2010UsageRecordThisMonth, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams UsageRecordThisMonth records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamUsageRecordThisMonth(params *ListUsageRecordThisMonthParams) (chan ApiV2010UsageRecordThisMonth, error) {
+func (c *ApiService) StreamUsageRecordThisMonth(params *ListUsageRecordThisMonthParams) (chan ApiV2010UsageRecordThisMonth, chan error) {
 	if params == nil {
 		params = &ListUsageRecordThisMonthParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010UsageRecordThisMonth, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageUsageRecordThisMonth(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamUsageRecordThisMonth(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamUsageRecordThisMonth(response *ListUsageRecordThisMonthResponse, params *ListUsageRecordThisMonthParams, recordChannel chan ApiV2010UsageRecordThisMonth, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010UsageRecordThisMonth, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.UsageRecords
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListUsageRecordThisMonthResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.UsageRecords
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListUsageRecordThisMonthResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListUsageRecordThisMonthResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListUsageRecordThisMonthResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListUsageRecordThisMonthResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_usage_records_yearly.go
+++ b/rest/api/v2010/accounts_usage_records_yearly.go
@@ -120,60 +120,70 @@ func (c *ApiService) PageUsageRecordYearly(params *ListUsageRecordYearlyParams, 
 
 // Lists UsageRecordYearly records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUsageRecordYearly(params *ListUsageRecordYearlyParams) ([]ApiV2010UsageRecordYearly, error) {
-	response, err := c.StreamUsageRecordYearly(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamUsageRecordYearly(params)
 
 	records := make([]ApiV2010UsageRecordYearly, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams UsageRecordYearly records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamUsageRecordYearly(params *ListUsageRecordYearlyParams) (chan ApiV2010UsageRecordYearly, error) {
+func (c *ApiService) StreamUsageRecordYearly(params *ListUsageRecordYearlyParams) (chan ApiV2010UsageRecordYearly, chan error) {
 	if params == nil {
 		params = &ListUsageRecordYearlyParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010UsageRecordYearly, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageUsageRecordYearly(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamUsageRecordYearly(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamUsageRecordYearly(response *ListUsageRecordYearlyResponse, params *ListUsageRecordYearlyParams, recordChannel chan ApiV2010UsageRecordYearly, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010UsageRecordYearly, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.UsageRecords
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListUsageRecordYearlyResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.UsageRecords
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListUsageRecordYearlyResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListUsageRecordYearlyResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListUsageRecordYearlyResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListUsageRecordYearlyResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_usage_records_yesterday.go
+++ b/rest/api/v2010/accounts_usage_records_yesterday.go
@@ -120,60 +120,70 @@ func (c *ApiService) PageUsageRecordYesterday(params *ListUsageRecordYesterdayPa
 
 // Lists UsageRecordYesterday records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUsageRecordYesterday(params *ListUsageRecordYesterdayParams) ([]ApiV2010UsageRecordYesterday, error) {
-	response, err := c.StreamUsageRecordYesterday(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamUsageRecordYesterday(params)
 
 	records := make([]ApiV2010UsageRecordYesterday, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams UsageRecordYesterday records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamUsageRecordYesterday(params *ListUsageRecordYesterdayParams) (chan ApiV2010UsageRecordYesterday, error) {
+func (c *ApiService) StreamUsageRecordYesterday(params *ListUsageRecordYesterdayParams) (chan ApiV2010UsageRecordYesterday, chan error) {
 	if params == nil {
 		params = &ListUsageRecordYesterdayParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010UsageRecordYesterday, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageUsageRecordYesterday(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamUsageRecordYesterday(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamUsageRecordYesterday(response *ListUsageRecordYesterdayResponse, params *ListUsageRecordYesterdayParams, recordChannel chan ApiV2010UsageRecordYesterday, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010UsageRecordYesterday, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.UsageRecords
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListUsageRecordYesterdayResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.UsageRecords
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListUsageRecordYesterdayResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListUsageRecordYesterdayResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListUsageRecordYesterdayResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListUsageRecordYesterdayResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/api/v2010/accounts_usage_triggers.go
+++ b/rest/api/v2010/accounts_usage_triggers.go
@@ -285,60 +285,70 @@ func (c *ApiService) PageUsageTrigger(params *ListUsageTriggerParams, pageToken,
 
 // Lists UsageTrigger records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUsageTrigger(params *ListUsageTriggerParams) ([]ApiV2010UsageTrigger, error) {
-	response, err := c.StreamUsageTrigger(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamUsageTrigger(params)
 
 	records := make([]ApiV2010UsageTrigger, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams UsageTrigger records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamUsageTrigger(params *ListUsageTriggerParams) (chan ApiV2010UsageTrigger, error) {
+func (c *ApiService) StreamUsageTrigger(params *ListUsageTriggerParams) (chan ApiV2010UsageTrigger, chan error) {
 	if params == nil {
 		params = &ListUsageTriggerParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ApiV2010UsageTrigger, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageUsageTrigger(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamUsageTrigger(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamUsageTrigger(response *ListUsageTriggerResponse, params *ListUsageTriggerParams, recordChannel chan ApiV2010UsageTrigger, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ApiV2010UsageTrigger, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.UsageTriggers
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListUsageTriggerResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.UsageTriggers
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListUsageTriggerResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListUsageTriggerResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListUsageTriggerResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListUsageTriggerResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/autopilot/v1/assistants_queries.go
+++ b/rest/autopilot/v1/assistants_queries.go
@@ -215,60 +215,70 @@ func (c *ApiService) PageQuery(AssistantSid string, params *ListQueryParams, pag
 
 // Lists Query records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListQuery(AssistantSid string, params *ListQueryParams) ([]AutopilotV1Query, error) {
-	response, err := c.StreamQuery(AssistantSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamQuery(AssistantSid, params)
 
 	records := make([]AutopilotV1Query, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Query records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamQuery(AssistantSid string, params *ListQueryParams) (chan AutopilotV1Query, error) {
+func (c *ApiService) StreamQuery(AssistantSid string, params *ListQueryParams) (chan AutopilotV1Query, chan error) {
 	if params == nil {
 		params = &ListQueryParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan AutopilotV1Query, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageQuery(AssistantSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamQuery(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamQuery(response *ListQueryResponse, params *ListQueryParams, recordChannel chan AutopilotV1Query, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan AutopilotV1Query, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Queries
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListQueryResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Queries
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListQueryResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListQueryResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListQueryResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListQueryResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/autopilot/v1/assistants_tasks.go
+++ b/rest/autopilot/v1/assistants_tasks.go
@@ -185,60 +185,70 @@ func (c *ApiService) PageTask(AssistantSid string, params *ListTaskParams, pageT
 
 // Lists Task records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListTask(AssistantSid string, params *ListTaskParams) ([]AutopilotV1Task, error) {
-	response, err := c.StreamTask(AssistantSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamTask(AssistantSid, params)
 
 	records := make([]AutopilotV1Task, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Task records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamTask(AssistantSid string, params *ListTaskParams) (chan AutopilotV1Task, error) {
+func (c *ApiService) StreamTask(AssistantSid string, params *ListTaskParams) (chan AutopilotV1Task, chan error) {
 	if params == nil {
 		params = &ListTaskParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan AutopilotV1Task, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageTask(AssistantSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamTask(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamTask(response *ListTaskResponse, params *ListTaskParams, recordChannel chan AutopilotV1Task, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan AutopilotV1Task, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Tasks
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListTaskResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Tasks
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListTaskResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListTaskResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListTaskResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListTaskResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/autopilot/v1/assistants_tasks_fields.go
+++ b/rest/autopilot/v1/assistants_tasks_fields.go
@@ -165,60 +165,70 @@ func (c *ApiService) PageField(AssistantSid string, TaskSid string, params *List
 
 // Lists Field records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListField(AssistantSid string, TaskSid string, params *ListFieldParams) ([]AutopilotV1Field, error) {
-	response, err := c.StreamField(AssistantSid, TaskSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamField(AssistantSid, TaskSid, params)
 
 	records := make([]AutopilotV1Field, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Field records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamField(AssistantSid string, TaskSid string, params *ListFieldParams) (chan AutopilotV1Field, error) {
+func (c *ApiService) StreamField(AssistantSid string, TaskSid string, params *ListFieldParams) (chan AutopilotV1Field, chan error) {
 	if params == nil {
 		params = &ListFieldParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan AutopilotV1Field, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageField(AssistantSid, TaskSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamField(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamField(response *ListFieldResponse, params *ListFieldParams, recordChannel chan AutopilotV1Field, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan AutopilotV1Field, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Fields
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListFieldResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Fields
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListFieldResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListFieldResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListFieldResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListFieldResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/autopilot/v1/assistants_webhooks.go
+++ b/rest/autopilot/v1/assistants_webhooks.go
@@ -179,60 +179,70 @@ func (c *ApiService) PageWebhook(AssistantSid string, params *ListWebhookParams,
 
 // Lists Webhook records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListWebhook(AssistantSid string, params *ListWebhookParams) ([]AutopilotV1Webhook, error) {
-	response, err := c.StreamWebhook(AssistantSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamWebhook(AssistantSid, params)
 
 	records := make([]AutopilotV1Webhook, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Webhook records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamWebhook(AssistantSid string, params *ListWebhookParams) (chan AutopilotV1Webhook, error) {
+func (c *ApiService) StreamWebhook(AssistantSid string, params *ListWebhookParams) (chan AutopilotV1Webhook, chan error) {
 	if params == nil {
 		params = &ListWebhookParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan AutopilotV1Webhook, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageWebhook(AssistantSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamWebhook(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamWebhook(response *ListWebhookResponse, params *ListWebhookParams, recordChannel chan AutopilotV1Webhook, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan AutopilotV1Webhook, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Webhooks
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListWebhookResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Webhooks
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListWebhookResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListWebhookResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListWebhookResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListWebhookResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/bulkexports/v1/exports_jobs.go
+++ b/rest/bulkexports/v1/exports_jobs.go
@@ -195,60 +195,70 @@ func (c *ApiService) PageExportCustomJob(ResourceType string, params *ListExport
 
 // Lists ExportCustomJob records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListExportCustomJob(ResourceType string, params *ListExportCustomJobParams) ([]BulkexportsV1ExportCustomJob, error) {
-	response, err := c.StreamExportCustomJob(ResourceType, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamExportCustomJob(ResourceType, params)
 
 	records := make([]BulkexportsV1ExportCustomJob, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ExportCustomJob records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamExportCustomJob(ResourceType string, params *ListExportCustomJobParams) (chan BulkexportsV1ExportCustomJob, error) {
+func (c *ApiService) StreamExportCustomJob(ResourceType string, params *ListExportCustomJobParams) (chan BulkexportsV1ExportCustomJob, chan error) {
 	if params == nil {
 		params = &ListExportCustomJobParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan BulkexportsV1ExportCustomJob, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageExportCustomJob(ResourceType, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamExportCustomJob(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamExportCustomJob(response *ListExportCustomJobResponse, params *ListExportCustomJobParams, recordChannel chan BulkexportsV1ExportCustomJob, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan BulkexportsV1ExportCustomJob, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Jobs
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListExportCustomJobResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Jobs
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListExportCustomJobResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListExportCustomJobResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListExportCustomJobResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListExportCustomJobResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/chat/v1/credentials.go
+++ b/rest/chat/v1/credentials.go
@@ -201,60 +201,70 @@ func (c *ApiService) PageCredential(params *ListCredentialParams, pageToken, pag
 
 // Lists Credential records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCredential(params *ListCredentialParams) ([]ChatV1Credential, error) {
-	response, err := c.StreamCredential(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamCredential(params)
 
 	records := make([]ChatV1Credential, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Credential records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamCredential(params *ListCredentialParams) (chan ChatV1Credential, error) {
+func (c *ApiService) StreamCredential(params *ListCredentialParams) (chan ChatV1Credential, chan error) {
 	if params == nil {
 		params = &ListCredentialParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ChatV1Credential, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageCredential(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamCredential(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamCredential(response *ListCredentialResponse, params *ListCredentialParams, recordChannel chan ChatV1Credential, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ChatV1Credential, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Credentials
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListCredentialResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Credentials
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListCredentialResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListCredentialResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListCredentialResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListCredentialResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/chat/v1/services.go
+++ b/rest/chat/v1/services.go
@@ -147,60 +147,70 @@ func (c *ApiService) PageService(params *ListServiceParams, pageToken, pageNumbe
 
 // Lists Service records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListService(params *ListServiceParams) ([]ChatV1Service, error) {
-	response, err := c.StreamService(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamService(params)
 
 	records := make([]ChatV1Service, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Service records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamService(params *ListServiceParams) (chan ChatV1Service, error) {
+func (c *ApiService) StreamService(params *ListServiceParams) (chan ChatV1Service, chan error) {
 	if params == nil {
 		params = &ListServiceParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ChatV1Service, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageService(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamService(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamService(response *ListServiceResponse, params *ListServiceParams, recordChannel chan ChatV1Service, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ChatV1Service, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Services
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Services
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListServiceResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListServiceResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListServiceResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListServiceResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/chat/v1/services_channels.go
+++ b/rest/chat/v1/services_channels.go
@@ -190,60 +190,70 @@ func (c *ApiService) PageChannel(ServiceSid string, params *ListChannelParams, p
 
 // Lists Channel records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListChannel(ServiceSid string, params *ListChannelParams) ([]ChatV1Channel, error) {
-	response, err := c.StreamChannel(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamChannel(ServiceSid, params)
 
 	records := make([]ChatV1Channel, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Channel records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamChannel(ServiceSid string, params *ListChannelParams) (chan ChatV1Channel, error) {
+func (c *ApiService) StreamChannel(ServiceSid string, params *ListChannelParams) (chan ChatV1Channel, chan error) {
 	if params == nil {
 		params = &ListChannelParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ChatV1Channel, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageChannel(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamChannel(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamChannel(response *ListChannelResponse, params *ListChannelParams, recordChannel chan ChatV1Channel, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ChatV1Channel, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Channels
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListChannelResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Channels
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListChannelResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListChannelResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListChannelResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListChannelResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/chat/v1/services_channels_invites.go
+++ b/rest/chat/v1/services_channels_invites.go
@@ -176,60 +176,70 @@ func (c *ApiService) PageInvite(ServiceSid string, ChannelSid string, params *Li
 
 // Lists Invite records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListInvite(ServiceSid string, ChannelSid string, params *ListInviteParams) ([]ChatV1Invite, error) {
-	response, err := c.StreamInvite(ServiceSid, ChannelSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamInvite(ServiceSid, ChannelSid, params)
 
 	records := make([]ChatV1Invite, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Invite records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamInvite(ServiceSid string, ChannelSid string, params *ListInviteParams) (chan ChatV1Invite, error) {
+func (c *ApiService) StreamInvite(ServiceSid string, ChannelSid string, params *ListInviteParams) (chan ChatV1Invite, chan error) {
 	if params == nil {
 		params = &ListInviteParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ChatV1Invite, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageInvite(ServiceSid, ChannelSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamInvite(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamInvite(response *ListInviteResponse, params *ListInviteParams, recordChannel chan ChatV1Invite, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ChatV1Invite, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Invites
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListInviteResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Invites
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListInviteResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListInviteResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListInviteResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListInviteResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/chat/v1/services_channels_messages.go
+++ b/rest/chat/v1/services_channels_messages.go
@@ -183,60 +183,70 @@ func (c *ApiService) PageMessage(ServiceSid string, ChannelSid string, params *L
 
 // Lists Message records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMessage(ServiceSid string, ChannelSid string, params *ListMessageParams) ([]ChatV1Message, error) {
-	response, err := c.StreamMessage(ServiceSid, ChannelSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamMessage(ServiceSid, ChannelSid, params)
 
 	records := make([]ChatV1Message, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Message records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamMessage(ServiceSid string, ChannelSid string, params *ListMessageParams) (chan ChatV1Message, error) {
+func (c *ApiService) StreamMessage(ServiceSid string, ChannelSid string, params *ListMessageParams) (chan ChatV1Message, chan error) {
 	if params == nil {
 		params = &ListMessageParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ChatV1Message, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageMessage(ServiceSid, ChannelSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamMessage(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamMessage(response *ListMessageResponse, params *ListMessageParams, recordChannel chan ChatV1Message, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ChatV1Message, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Messages
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListMessageResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Messages
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListMessageResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListMessageResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListMessageResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListMessageResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/chat/v1/services_roles.go
+++ b/rest/chat/v1/services_roles.go
@@ -172,60 +172,70 @@ func (c *ApiService) PageRole(ServiceSid string, params *ListRoleParams, pageTok
 
 // Lists Role records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRole(ServiceSid string, params *ListRoleParams) ([]ChatV1Role, error) {
-	response, err := c.StreamRole(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamRole(ServiceSid, params)
 
 	records := make([]ChatV1Role, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Role records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamRole(ServiceSid string, params *ListRoleParams) (chan ChatV1Role, error) {
+func (c *ApiService) StreamRole(ServiceSid string, params *ListRoleParams) (chan ChatV1Role, chan error) {
 	if params == nil {
 		params = &ListRoleParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ChatV1Role, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageRole(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamRole(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamRole(response *ListRoleResponse, params *ListRoleParams, recordChannel chan ChatV1Role, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ChatV1Role, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Roles
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListRoleResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Roles
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListRoleResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListRoleResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListRoleResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListRoleResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/chat/v1/services_users.go
+++ b/rest/chat/v1/services_users.go
@@ -179,60 +179,70 @@ func (c *ApiService) PageUser(ServiceSid string, params *ListUserParams, pageTok
 
 // Lists User records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUser(ServiceSid string, params *ListUserParams) ([]ChatV1User, error) {
-	response, err := c.StreamUser(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamUser(ServiceSid, params)
 
 	records := make([]ChatV1User, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams User records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamUser(ServiceSid string, params *ListUserParams) (chan ChatV1User, error) {
+func (c *ApiService) StreamUser(ServiceSid string, params *ListUserParams) (chan ChatV1User, chan error) {
 	if params == nil {
 		params = &ListUserParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ChatV1User, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageUser(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamUser(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamUser(response *ListUserResponse, params *ListUserParams, recordChannel chan ChatV1User, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ChatV1User, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Users
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListUserResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Users
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListUserResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListUserResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListUserResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListUserResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/chat/v1/services_users_channels.go
+++ b/rest/chat/v1/services_users_channels.go
@@ -75,60 +75,70 @@ func (c *ApiService) PageUserChannel(ServiceSid string, UserSid string, params *
 
 // Lists UserChannel records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUserChannel(ServiceSid string, UserSid string, params *ListUserChannelParams) ([]ChatV1UserChannel, error) {
-	response, err := c.StreamUserChannel(ServiceSid, UserSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamUserChannel(ServiceSid, UserSid, params)
 
 	records := make([]ChatV1UserChannel, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams UserChannel records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamUserChannel(ServiceSid string, UserSid string, params *ListUserChannelParams) (chan ChatV1UserChannel, error) {
+func (c *ApiService) StreamUserChannel(ServiceSid string, UserSid string, params *ListUserChannelParams) (chan ChatV1UserChannel, chan error) {
 	if params == nil {
 		params = &ListUserChannelParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ChatV1UserChannel, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageUserChannel(ServiceSid, UserSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamUserChannel(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamUserChannel(response *ListUserChannelResponse, params *ListUserChannelParams, recordChannel chan ChatV1UserChannel, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ChatV1UserChannel, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Channels
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListUserChannelResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Channels
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListUserChannelResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListUserChannelResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListUserChannelResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListUserChannelResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/chat/v2/credentials.go
+++ b/rest/chat/v2/credentials.go
@@ -201,60 +201,70 @@ func (c *ApiService) PageCredential(params *ListCredentialParams, pageToken, pag
 
 // Lists Credential records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCredential(params *ListCredentialParams) ([]ChatV2Credential, error) {
-	response, err := c.StreamCredential(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamCredential(params)
 
 	records := make([]ChatV2Credential, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Credential records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamCredential(params *ListCredentialParams) (chan ChatV2Credential, error) {
+func (c *ApiService) StreamCredential(params *ListCredentialParams) (chan ChatV2Credential, chan error) {
 	if params == nil {
 		params = &ListCredentialParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ChatV2Credential, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageCredential(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamCredential(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamCredential(response *ListCredentialResponse, params *ListCredentialParams, recordChannel chan ChatV2Credential, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ChatV2Credential, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Credentials
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListCredentialResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Credentials
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListCredentialResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListCredentialResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListCredentialResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListCredentialResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/chat/v2/services.go
+++ b/rest/chat/v2/services.go
@@ -147,60 +147,70 @@ func (c *ApiService) PageService(params *ListServiceParams, pageToken, pageNumbe
 
 // Lists Service records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListService(params *ListServiceParams) ([]ChatV2Service, error) {
-	response, err := c.StreamService(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamService(params)
 
 	records := make([]ChatV2Service, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Service records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamService(params *ListServiceParams) (chan ChatV2Service, error) {
+func (c *ApiService) StreamService(params *ListServiceParams) (chan ChatV2Service, chan error) {
 	if params == nil {
 		params = &ListServiceParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ChatV2Service, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageService(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamService(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamService(response *ListServiceResponse, params *ListServiceParams, recordChannel chan ChatV2Service, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ChatV2Service, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Services
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Services
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListServiceResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListServiceResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListServiceResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListServiceResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/chat/v2/services_channels.go
+++ b/rest/chat/v2/services_channels.go
@@ -243,60 +243,70 @@ func (c *ApiService) PageChannel(ServiceSid string, params *ListChannelParams, p
 
 // Lists Channel records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListChannel(ServiceSid string, params *ListChannelParams) ([]ChatV2Channel, error) {
-	response, err := c.StreamChannel(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamChannel(ServiceSid, params)
 
 	records := make([]ChatV2Channel, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Channel records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamChannel(ServiceSid string, params *ListChannelParams) (chan ChatV2Channel, error) {
+func (c *ApiService) StreamChannel(ServiceSid string, params *ListChannelParams) (chan ChatV2Channel, chan error) {
 	if params == nil {
 		params = &ListChannelParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ChatV2Channel, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageChannel(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamChannel(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamChannel(response *ListChannelResponse, params *ListChannelParams, recordChannel chan ChatV2Channel, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ChatV2Channel, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Channels
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListChannelResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Channels
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListChannelResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListChannelResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListChannelResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListChannelResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/chat/v2/services_channels_invites.go
+++ b/rest/chat/v2/services_channels_invites.go
@@ -176,60 +176,70 @@ func (c *ApiService) PageInvite(ServiceSid string, ChannelSid string, params *Li
 
 // Lists Invite records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListInvite(ServiceSid string, ChannelSid string, params *ListInviteParams) ([]ChatV2Invite, error) {
-	response, err := c.StreamInvite(ServiceSid, ChannelSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamInvite(ServiceSid, ChannelSid, params)
 
 	records := make([]ChatV2Invite, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Invite records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamInvite(ServiceSid string, ChannelSid string, params *ListInviteParams) (chan ChatV2Invite, error) {
+func (c *ApiService) StreamInvite(ServiceSid string, ChannelSid string, params *ListInviteParams) (chan ChatV2Invite, chan error) {
 	if params == nil {
 		params = &ListInviteParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ChatV2Invite, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageInvite(ServiceSid, ChannelSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamInvite(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamInvite(response *ListInviteResponse, params *ListInviteParams, recordChannel chan ChatV2Invite, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ChatV2Invite, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Invites
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListInviteResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Invites
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListInviteResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListInviteResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListInviteResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListInviteResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/chat/v2/services_channels_members.go
+++ b/rest/chat/v2/services_channels_members.go
@@ -247,60 +247,70 @@ func (c *ApiService) PageMember(ServiceSid string, ChannelSid string, params *Li
 
 // Lists Member records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMember(ServiceSid string, ChannelSid string, params *ListMemberParams) ([]ChatV2Member, error) {
-	response, err := c.StreamMember(ServiceSid, ChannelSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamMember(ServiceSid, ChannelSid, params)
 
 	records := make([]ChatV2Member, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Member records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamMember(ServiceSid string, ChannelSid string, params *ListMemberParams) (chan ChatV2Member, error) {
+func (c *ApiService) StreamMember(ServiceSid string, ChannelSid string, params *ListMemberParams) (chan ChatV2Member, chan error) {
 	if params == nil {
 		params = &ListMemberParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ChatV2Member, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageMember(ServiceSid, ChannelSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamMember(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamMember(response *ListMemberResponse, params *ListMemberParams, recordChannel chan ChatV2Member, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ChatV2Member, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Members
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListMemberResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Members
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListMemberResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListMemberResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListMemberResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListMemberResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/chat/v2/services_channels_messages.go
+++ b/rest/chat/v2/services_channels_messages.go
@@ -245,60 +245,70 @@ func (c *ApiService) PageMessage(ServiceSid string, ChannelSid string, params *L
 
 // Lists Message records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMessage(ServiceSid string, ChannelSid string, params *ListMessageParams) ([]ChatV2Message, error) {
-	response, err := c.StreamMessage(ServiceSid, ChannelSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamMessage(ServiceSid, ChannelSid, params)
 
 	records := make([]ChatV2Message, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Message records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamMessage(ServiceSid string, ChannelSid string, params *ListMessageParams) (chan ChatV2Message, error) {
+func (c *ApiService) StreamMessage(ServiceSid string, ChannelSid string, params *ListMessageParams) (chan ChatV2Message, chan error) {
 	if params == nil {
 		params = &ListMessageParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ChatV2Message, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageMessage(ServiceSid, ChannelSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamMessage(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamMessage(response *ListMessageResponse, params *ListMessageParams, recordChannel chan ChatV2Message, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ChatV2Message, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Messages
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListMessageResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Messages
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListMessageResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListMessageResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListMessageResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListMessageResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/chat/v2/services_channels_webhooks.go
+++ b/rest/chat/v2/services_channels_webhooks.go
@@ -214,60 +214,70 @@ func (c *ApiService) PageChannelWebhook(ServiceSid string, ChannelSid string, pa
 
 // Lists ChannelWebhook records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListChannelWebhook(ServiceSid string, ChannelSid string, params *ListChannelWebhookParams) ([]ChatV2ChannelWebhook, error) {
-	response, err := c.StreamChannelWebhook(ServiceSid, ChannelSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamChannelWebhook(ServiceSid, ChannelSid, params)
 
 	records := make([]ChatV2ChannelWebhook, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ChannelWebhook records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamChannelWebhook(ServiceSid string, ChannelSid string, params *ListChannelWebhookParams) (chan ChatV2ChannelWebhook, error) {
+func (c *ApiService) StreamChannelWebhook(ServiceSid string, ChannelSid string, params *ListChannelWebhookParams) (chan ChatV2ChannelWebhook, chan error) {
 	if params == nil {
 		params = &ListChannelWebhookParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ChatV2ChannelWebhook, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageChannelWebhook(ServiceSid, ChannelSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamChannelWebhook(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamChannelWebhook(response *ListChannelWebhookResponse, params *ListChannelWebhookParams, recordChannel chan ChatV2ChannelWebhook, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ChatV2ChannelWebhook, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Webhooks
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListChannelWebhookResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Webhooks
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListChannelWebhookResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListChannelWebhookResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListChannelWebhookResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListChannelWebhookResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/chat/v2/services_roles.go
+++ b/rest/chat/v2/services_roles.go
@@ -172,60 +172,70 @@ func (c *ApiService) PageRole(ServiceSid string, params *ListRoleParams, pageTok
 
 // Lists Role records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRole(ServiceSid string, params *ListRoleParams) ([]ChatV2Role, error) {
-	response, err := c.StreamRole(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamRole(ServiceSid, params)
 
 	records := make([]ChatV2Role, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Role records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamRole(ServiceSid string, params *ListRoleParams) (chan ChatV2Role, error) {
+func (c *ApiService) StreamRole(ServiceSid string, params *ListRoleParams) (chan ChatV2Role, chan error) {
 	if params == nil {
 		params = &ListRoleParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ChatV2Role, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageRole(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamRole(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamRole(response *ListRoleResponse, params *ListRoleParams, recordChannel chan ChatV2Role, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ChatV2Role, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Roles
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListRoleResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Roles
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListRoleResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListRoleResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListRoleResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListRoleResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/chat/v2/services_users.go
+++ b/rest/chat/v2/services_users.go
@@ -189,60 +189,70 @@ func (c *ApiService) PageUser(ServiceSid string, params *ListUserParams, pageTok
 
 // Lists User records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUser(ServiceSid string, params *ListUserParams) ([]ChatV2User, error) {
-	response, err := c.StreamUser(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamUser(ServiceSid, params)
 
 	records := make([]ChatV2User, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams User records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamUser(ServiceSid string, params *ListUserParams) (chan ChatV2User, error) {
+func (c *ApiService) StreamUser(ServiceSid string, params *ListUserParams) (chan ChatV2User, chan error) {
 	if params == nil {
 		params = &ListUserParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ChatV2User, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageUser(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamUser(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamUser(response *ListUserResponse, params *ListUserParams, recordChannel chan ChatV2User, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ChatV2User, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Users
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListUserResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Users
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListUserResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListUserResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListUserResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListUserResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/chat/v2/services_users_bindings.go
+++ b/rest/chat/v2/services_users_bindings.go
@@ -129,60 +129,70 @@ func (c *ApiService) PageUserBinding(ServiceSid string, UserSid string, params *
 
 // Lists UserBinding records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUserBinding(ServiceSid string, UserSid string, params *ListUserBindingParams) ([]ChatV2UserBinding, error) {
-	response, err := c.StreamUserBinding(ServiceSid, UserSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamUserBinding(ServiceSid, UserSid, params)
 
 	records := make([]ChatV2UserBinding, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams UserBinding records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamUserBinding(ServiceSid string, UserSid string, params *ListUserBindingParams) (chan ChatV2UserBinding, error) {
+func (c *ApiService) StreamUserBinding(ServiceSid string, UserSid string, params *ListUserBindingParams) (chan ChatV2UserBinding, chan error) {
 	if params == nil {
 		params = &ListUserBindingParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ChatV2UserBinding, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageUserBinding(ServiceSid, UserSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamUserBinding(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamUserBinding(response *ListUserBindingResponse, params *ListUserBindingParams, recordChannel chan ChatV2UserBinding, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ChatV2UserBinding, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Bindings
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListUserBindingResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Bindings
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListUserBindingResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListUserBindingResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListUserBindingResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListUserBindingResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/chat/v2/services_users_channels.go
+++ b/rest/chat/v2/services_users_channels.go
@@ -135,60 +135,70 @@ func (c *ApiService) PageUserChannel(ServiceSid string, UserSid string, params *
 
 // Lists UserChannel records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUserChannel(ServiceSid string, UserSid string, params *ListUserChannelParams) ([]ChatV2UserChannel, error) {
-	response, err := c.StreamUserChannel(ServiceSid, UserSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamUserChannel(ServiceSid, UserSid, params)
 
 	records := make([]ChatV2UserChannel, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams UserChannel records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamUserChannel(ServiceSid string, UserSid string, params *ListUserChannelParams) (chan ChatV2UserChannel, error) {
+func (c *ApiService) StreamUserChannel(ServiceSid string, UserSid string, params *ListUserChannelParams) (chan ChatV2UserChannel, chan error) {
 	if params == nil {
 		params = &ListUserChannelParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ChatV2UserChannel, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageUserChannel(ServiceSid, UserSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamUserChannel(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamUserChannel(response *ListUserChannelResponse, params *ListUserChannelParams, recordChannel chan ChatV2UserChannel, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ChatV2UserChannel, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Channels
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListUserChannelResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Channels
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListUserChannelResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListUserChannelResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListUserChannelResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListUserChannelResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/conversations/v1/configuration_addresses.go
+++ b/rest/conversations/v1/configuration_addresses.go
@@ -242,60 +242,70 @@ func (c *ApiService) PageConfigurationAddress(params *ListConfigurationAddressPa
 
 // Lists ConfigurationAddress records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListConfigurationAddress(params *ListConfigurationAddressParams) ([]ConversationsV1ConfigurationAddress, error) {
-	response, err := c.StreamConfigurationAddress(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamConfigurationAddress(params)
 
 	records := make([]ConversationsV1ConfigurationAddress, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ConfigurationAddress records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamConfigurationAddress(params *ListConfigurationAddressParams) (chan ConversationsV1ConfigurationAddress, error) {
+func (c *ApiService) StreamConfigurationAddress(params *ListConfigurationAddressParams) (chan ConversationsV1ConfigurationAddress, chan error) {
 	if params == nil {
 		params = &ListConfigurationAddressParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ConversationsV1ConfigurationAddress, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageConfigurationAddress(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamConfigurationAddress(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamConfigurationAddress(response *ListConfigurationAddressResponse, params *ListConfigurationAddressParams, recordChannel chan ConversationsV1ConfigurationAddress, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ConversationsV1ConfigurationAddress, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.AddressConfigurations
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListConfigurationAddressResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.AddressConfigurations
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListConfigurationAddressResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListConfigurationAddressResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListConfigurationAddressResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListConfigurationAddressResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/conversations/v1/conversations.go
+++ b/rest/conversations/v1/conversations.go
@@ -248,60 +248,70 @@ func (c *ApiService) PageConversation(params *ListConversationParams, pageToken,
 
 // Lists Conversation records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListConversation(params *ListConversationParams) ([]ConversationsV1Conversation, error) {
-	response, err := c.StreamConversation(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamConversation(params)
 
 	records := make([]ConversationsV1Conversation, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Conversation records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamConversation(params *ListConversationParams) (chan ConversationsV1Conversation, error) {
+func (c *ApiService) StreamConversation(params *ListConversationParams) (chan ConversationsV1Conversation, chan error) {
 	if params == nil {
 		params = &ListConversationParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ConversationsV1Conversation, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageConversation(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamConversation(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamConversation(response *ListConversationResponse, params *ListConversationParams, recordChannel chan ConversationsV1Conversation, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ConversationsV1Conversation, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Conversations
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListConversationResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Conversations
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListConversationResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListConversationResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListConversationResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListConversationResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/conversations/v1/conversations_messages_receipts.go
+++ b/rest/conversations/v1/conversations_messages_receipts.go
@@ -100,60 +100,70 @@ func (c *ApiService) PageConversationMessageReceipt(ConversationSid string, Mess
 
 // Lists ConversationMessageReceipt records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListConversationMessageReceipt(ConversationSid string, MessageSid string, params *ListConversationMessageReceiptParams) ([]ConversationsV1ConversationMessageReceipt, error) {
-	response, err := c.StreamConversationMessageReceipt(ConversationSid, MessageSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamConversationMessageReceipt(ConversationSid, MessageSid, params)
 
 	records := make([]ConversationsV1ConversationMessageReceipt, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ConversationMessageReceipt records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamConversationMessageReceipt(ConversationSid string, MessageSid string, params *ListConversationMessageReceiptParams) (chan ConversationsV1ConversationMessageReceipt, error) {
+func (c *ApiService) StreamConversationMessageReceipt(ConversationSid string, MessageSid string, params *ListConversationMessageReceiptParams) (chan ConversationsV1ConversationMessageReceipt, chan error) {
 	if params == nil {
 		params = &ListConversationMessageReceiptParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ConversationsV1ConversationMessageReceipt, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageConversationMessageReceipt(ConversationSid, MessageSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamConversationMessageReceipt(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamConversationMessageReceipt(response *ListConversationMessageReceiptResponse, params *ListConversationMessageReceiptParams, recordChannel chan ConversationsV1ConversationMessageReceipt, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ConversationsV1ConversationMessageReceipt, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.DeliveryReceipts
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListConversationMessageReceiptResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.DeliveryReceipts
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListConversationMessageReceiptResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListConversationMessageReceiptResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListConversationMessageReceiptResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListConversationMessageReceiptResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/conversations/v1/conversations_webhooks.go
+++ b/rest/conversations/v1/conversations_webhooks.go
@@ -213,60 +213,70 @@ func (c *ApiService) PageConversationScopedWebhook(ConversationSid string, param
 
 // Lists ConversationScopedWebhook records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListConversationScopedWebhook(ConversationSid string, params *ListConversationScopedWebhookParams) ([]ConversationsV1ConversationScopedWebhook, error) {
-	response, err := c.StreamConversationScopedWebhook(ConversationSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamConversationScopedWebhook(ConversationSid, params)
 
 	records := make([]ConversationsV1ConversationScopedWebhook, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ConversationScopedWebhook records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamConversationScopedWebhook(ConversationSid string, params *ListConversationScopedWebhookParams) (chan ConversationsV1ConversationScopedWebhook, error) {
+func (c *ApiService) StreamConversationScopedWebhook(ConversationSid string, params *ListConversationScopedWebhookParams) (chan ConversationsV1ConversationScopedWebhook, chan error) {
 	if params == nil {
 		params = &ListConversationScopedWebhookParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ConversationsV1ConversationScopedWebhook, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageConversationScopedWebhook(ConversationSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamConversationScopedWebhook(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamConversationScopedWebhook(response *ListConversationScopedWebhookResponse, params *ListConversationScopedWebhookParams, recordChannel chan ConversationsV1ConversationScopedWebhook, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ConversationsV1ConversationScopedWebhook, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Webhooks
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListConversationScopedWebhookResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Webhooks
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListConversationScopedWebhookResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListConversationScopedWebhookResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListConversationScopedWebhookResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListConversationScopedWebhookResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/conversations/v1/credentials.go
+++ b/rest/conversations/v1/credentials.go
@@ -204,60 +204,70 @@ func (c *ApiService) PageCredential(params *ListCredentialParams, pageToken, pag
 
 // Lists Credential records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCredential(params *ListCredentialParams) ([]ConversationsV1Credential, error) {
-	response, err := c.StreamCredential(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamCredential(params)
 
 	records := make([]ConversationsV1Credential, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Credential records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamCredential(params *ListCredentialParams) (chan ConversationsV1Credential, error) {
+func (c *ApiService) StreamCredential(params *ListCredentialParams) (chan ConversationsV1Credential, chan error) {
 	if params == nil {
 		params = &ListCredentialParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ConversationsV1Credential, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageCredential(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamCredential(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamCredential(response *ListCredentialResponse, params *ListCredentialParams, recordChannel chan ConversationsV1Credential, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ConversationsV1Credential, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Credentials
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListCredentialResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Credentials
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListCredentialResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListCredentialResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListCredentialResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListCredentialResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/conversations/v1/participant_conversations.go
+++ b/rest/conversations/v1/participant_conversations.go
@@ -89,60 +89,70 @@ func (c *ApiService) PageParticipantConversation(params *ListParticipantConversa
 
 // Lists ParticipantConversation records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListParticipantConversation(params *ListParticipantConversationParams) ([]ConversationsV1ParticipantConversation, error) {
-	response, err := c.StreamParticipantConversation(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamParticipantConversation(params)
 
 	records := make([]ConversationsV1ParticipantConversation, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ParticipantConversation records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamParticipantConversation(params *ListParticipantConversationParams) (chan ConversationsV1ParticipantConversation, error) {
+func (c *ApiService) StreamParticipantConversation(params *ListParticipantConversationParams) (chan ConversationsV1ParticipantConversation, chan error) {
 	if params == nil {
 		params = &ListParticipantConversationParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ConversationsV1ParticipantConversation, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageParticipantConversation(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamParticipantConversation(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamParticipantConversation(response *ListParticipantConversationResponse, params *ListParticipantConversationParams, recordChannel chan ConversationsV1ParticipantConversation, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ConversationsV1ParticipantConversation, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Conversations
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListParticipantConversationResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Conversations
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListParticipantConversationResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListParticipantConversationResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListParticipantConversationResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListParticipantConversationResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/conversations/v1/roles.go
+++ b/rest/conversations/v1/roles.go
@@ -170,60 +170,70 @@ func (c *ApiService) PageRole(params *ListRoleParams, pageToken, pageNumber stri
 
 // Lists Role records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRole(params *ListRoleParams) ([]ConversationsV1Role, error) {
-	response, err := c.StreamRole(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamRole(params)
 
 	records := make([]ConversationsV1Role, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Role records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamRole(params *ListRoleParams) (chan ConversationsV1Role, error) {
+func (c *ApiService) StreamRole(params *ListRoleParams) (chan ConversationsV1Role, chan error) {
 	if params == nil {
 		params = &ListRoleParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ConversationsV1Role, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageRole(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamRole(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamRole(response *ListRoleResponse, params *ListRoleParams, recordChannel chan ConversationsV1Role, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ConversationsV1Role, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Roles
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListRoleResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Roles
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListRoleResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListRoleResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListRoleResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListRoleResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/conversations/v1/services.go
+++ b/rest/conversations/v1/services.go
@@ -150,60 +150,70 @@ func (c *ApiService) PageService(params *ListServiceParams, pageToken, pageNumbe
 
 // Lists Service records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListService(params *ListServiceParams) ([]ConversationsV1Service, error) {
-	response, err := c.StreamService(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamService(params)
 
 	records := make([]ConversationsV1Service, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Service records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamService(params *ListServiceParams) (chan ConversationsV1Service, error) {
+func (c *ApiService) StreamService(params *ListServiceParams) (chan ConversationsV1Service, chan error) {
 	if params == nil {
 		params = &ListServiceParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ConversationsV1Service, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageService(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamService(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamService(response *ListServiceResponse, params *ListServiceParams, recordChannel chan ConversationsV1Service, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ConversationsV1Service, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Services
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Services
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListServiceResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListServiceResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListServiceResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListServiceResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/conversations/v1/services_bindings.go
+++ b/rest/conversations/v1/services_bindings.go
@@ -139,60 +139,70 @@ func (c *ApiService) PageServiceBinding(ChatServiceSid string, params *ListServi
 
 // Lists ServiceBinding records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListServiceBinding(ChatServiceSid string, params *ListServiceBindingParams) ([]ConversationsV1ServiceBinding, error) {
-	response, err := c.StreamServiceBinding(ChatServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamServiceBinding(ChatServiceSid, params)
 
 	records := make([]ConversationsV1ServiceBinding, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ServiceBinding records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamServiceBinding(ChatServiceSid string, params *ListServiceBindingParams) (chan ConversationsV1ServiceBinding, error) {
+func (c *ApiService) StreamServiceBinding(ChatServiceSid string, params *ListServiceBindingParams) (chan ConversationsV1ServiceBinding, chan error) {
 	if params == nil {
 		params = &ListServiceBindingParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ConversationsV1ServiceBinding, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageServiceBinding(ChatServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamServiceBinding(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamServiceBinding(response *ListServiceBindingResponse, params *ListServiceBindingParams, recordChannel chan ConversationsV1ServiceBinding, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ConversationsV1ServiceBinding, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Bindings
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceBindingResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Bindings
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListServiceBindingResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListServiceBindingResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListServiceBindingResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListServiceBindingResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/conversations/v1/services_conversations_messages.go
+++ b/rest/conversations/v1/services_conversations_messages.go
@@ -239,60 +239,70 @@ func (c *ApiService) PageServiceConversationMessage(ChatServiceSid string, Conve
 
 // Lists ServiceConversationMessage records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListServiceConversationMessage(ChatServiceSid string, ConversationSid string, params *ListServiceConversationMessageParams) ([]ConversationsV1ServiceConversationMessage, error) {
-	response, err := c.StreamServiceConversationMessage(ChatServiceSid, ConversationSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamServiceConversationMessage(ChatServiceSid, ConversationSid, params)
 
 	records := make([]ConversationsV1ServiceConversationMessage, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ServiceConversationMessage records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamServiceConversationMessage(ChatServiceSid string, ConversationSid string, params *ListServiceConversationMessageParams) (chan ConversationsV1ServiceConversationMessage, error) {
+func (c *ApiService) StreamServiceConversationMessage(ChatServiceSid string, ConversationSid string, params *ListServiceConversationMessageParams) (chan ConversationsV1ServiceConversationMessage, chan error) {
 	if params == nil {
 		params = &ListServiceConversationMessageParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ConversationsV1ServiceConversationMessage, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageServiceConversationMessage(ChatServiceSid, ConversationSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamServiceConversationMessage(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamServiceConversationMessage(response *ListServiceConversationMessageResponse, params *ListServiceConversationMessageParams, recordChannel chan ConversationsV1ServiceConversationMessage, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ConversationsV1ServiceConversationMessage, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Messages
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceConversationMessageResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Messages
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListServiceConversationMessageResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListServiceConversationMessageResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListServiceConversationMessageResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListServiceConversationMessageResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/conversations/v1/services_conversations_messages_receipts.go
+++ b/rest/conversations/v1/services_conversations_messages_receipts.go
@@ -102,60 +102,70 @@ func (c *ApiService) PageServiceConversationMessageReceipt(ChatServiceSid string
 
 // Lists ServiceConversationMessageReceipt records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListServiceConversationMessageReceipt(ChatServiceSid string, ConversationSid string, MessageSid string, params *ListServiceConversationMessageReceiptParams) ([]ConversationsV1ServiceConversationMessageReceipt, error) {
-	response, err := c.StreamServiceConversationMessageReceipt(ChatServiceSid, ConversationSid, MessageSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamServiceConversationMessageReceipt(ChatServiceSid, ConversationSid, MessageSid, params)
 
 	records := make([]ConversationsV1ServiceConversationMessageReceipt, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ServiceConversationMessageReceipt records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamServiceConversationMessageReceipt(ChatServiceSid string, ConversationSid string, MessageSid string, params *ListServiceConversationMessageReceiptParams) (chan ConversationsV1ServiceConversationMessageReceipt, error) {
+func (c *ApiService) StreamServiceConversationMessageReceipt(ChatServiceSid string, ConversationSid string, MessageSid string, params *ListServiceConversationMessageReceiptParams) (chan ConversationsV1ServiceConversationMessageReceipt, chan error) {
 	if params == nil {
 		params = &ListServiceConversationMessageReceiptParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ConversationsV1ServiceConversationMessageReceipt, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageServiceConversationMessageReceipt(ChatServiceSid, ConversationSid, MessageSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamServiceConversationMessageReceipt(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamServiceConversationMessageReceipt(response *ListServiceConversationMessageReceiptResponse, params *ListServiceConversationMessageReceiptParams, recordChannel chan ConversationsV1ServiceConversationMessageReceipt, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ConversationsV1ServiceConversationMessageReceipt, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.DeliveryReceipts
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceConversationMessageReceiptResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.DeliveryReceipts
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListServiceConversationMessageReceiptResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListServiceConversationMessageReceiptResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListServiceConversationMessageReceiptResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListServiceConversationMessageReceiptResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/conversations/v1/services_conversations_webhooks.go
+++ b/rest/conversations/v1/services_conversations_webhooks.go
@@ -217,60 +217,70 @@ func (c *ApiService) PageServiceConversationScopedWebhook(ChatServiceSid string,
 
 // Lists ServiceConversationScopedWebhook records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListServiceConversationScopedWebhook(ChatServiceSid string, ConversationSid string, params *ListServiceConversationScopedWebhookParams) ([]ConversationsV1ServiceConversationScopedWebhook, error) {
-	response, err := c.StreamServiceConversationScopedWebhook(ChatServiceSid, ConversationSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamServiceConversationScopedWebhook(ChatServiceSid, ConversationSid, params)
 
 	records := make([]ConversationsV1ServiceConversationScopedWebhook, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ServiceConversationScopedWebhook records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamServiceConversationScopedWebhook(ChatServiceSid string, ConversationSid string, params *ListServiceConversationScopedWebhookParams) (chan ConversationsV1ServiceConversationScopedWebhook, error) {
+func (c *ApiService) StreamServiceConversationScopedWebhook(ChatServiceSid string, ConversationSid string, params *ListServiceConversationScopedWebhookParams) (chan ConversationsV1ServiceConversationScopedWebhook, chan error) {
 	if params == nil {
 		params = &ListServiceConversationScopedWebhookParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ConversationsV1ServiceConversationScopedWebhook, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageServiceConversationScopedWebhook(ChatServiceSid, ConversationSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamServiceConversationScopedWebhook(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamServiceConversationScopedWebhook(response *ListServiceConversationScopedWebhookResponse, params *ListServiceConversationScopedWebhookParams, recordChannel chan ConversationsV1ServiceConversationScopedWebhook, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ConversationsV1ServiceConversationScopedWebhook, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Webhooks
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceConversationScopedWebhookResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Webhooks
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListServiceConversationScopedWebhookResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListServiceConversationScopedWebhookResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListServiceConversationScopedWebhookResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListServiceConversationScopedWebhookResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/conversations/v1/services_participant_conversations.go
+++ b/rest/conversations/v1/services_participant_conversations.go
@@ -92,60 +92,70 @@ func (c *ApiService) PageServiceParticipantConversation(ChatServiceSid string, p
 
 // Lists ServiceParticipantConversation records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListServiceParticipantConversation(ChatServiceSid string, params *ListServiceParticipantConversationParams) ([]ConversationsV1ServiceParticipantConversation, error) {
-	response, err := c.StreamServiceParticipantConversation(ChatServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamServiceParticipantConversation(ChatServiceSid, params)
 
 	records := make([]ConversationsV1ServiceParticipantConversation, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ServiceParticipantConversation records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamServiceParticipantConversation(ChatServiceSid string, params *ListServiceParticipantConversationParams) (chan ConversationsV1ServiceParticipantConversation, error) {
+func (c *ApiService) StreamServiceParticipantConversation(ChatServiceSid string, params *ListServiceParticipantConversationParams) (chan ConversationsV1ServiceParticipantConversation, chan error) {
 	if params == nil {
 		params = &ListServiceParticipantConversationParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ConversationsV1ServiceParticipantConversation, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageServiceParticipantConversation(ChatServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamServiceParticipantConversation(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamServiceParticipantConversation(response *ListServiceParticipantConversationResponse, params *ListServiceParticipantConversationParams, recordChannel chan ConversationsV1ServiceParticipantConversation, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ConversationsV1ServiceParticipantConversation, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Conversations
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceParticipantConversationResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Conversations
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListServiceParticipantConversationResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListServiceParticipantConversationResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListServiceParticipantConversationResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListServiceParticipantConversationResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/conversations/v1/services_users_conversations.go
+++ b/rest/conversations/v1/services_users_conversations.go
@@ -121,60 +121,70 @@ func (c *ApiService) PageServiceUserConversation(ChatServiceSid string, UserSid 
 
 // Lists ServiceUserConversation records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListServiceUserConversation(ChatServiceSid string, UserSid string, params *ListServiceUserConversationParams) ([]ConversationsV1ServiceUserConversation, error) {
-	response, err := c.StreamServiceUserConversation(ChatServiceSid, UserSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamServiceUserConversation(ChatServiceSid, UserSid, params)
 
 	records := make([]ConversationsV1ServiceUserConversation, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ServiceUserConversation records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamServiceUserConversation(ChatServiceSid string, UserSid string, params *ListServiceUserConversationParams) (chan ConversationsV1ServiceUserConversation, error) {
+func (c *ApiService) StreamServiceUserConversation(ChatServiceSid string, UserSid string, params *ListServiceUserConversationParams) (chan ConversationsV1ServiceUserConversation, chan error) {
 	if params == nil {
 		params = &ListServiceUserConversationParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ConversationsV1ServiceUserConversation, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageServiceUserConversation(ChatServiceSid, UserSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamServiceUserConversation(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamServiceUserConversation(response *ListServiceUserConversationResponse, params *ListServiceUserConversationParams, recordChannel chan ConversationsV1ServiceUserConversation, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ConversationsV1ServiceUserConversation, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Conversations
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceUserConversationResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Conversations
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListServiceUserConversationResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListServiceUserConversationResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListServiceUserConversationResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListServiceUserConversationResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/conversations/v1/users.go
+++ b/rest/conversations/v1/users.go
@@ -202,60 +202,70 @@ func (c *ApiService) PageUser(params *ListUserParams, pageToken, pageNumber stri
 
 // Lists User records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUser(params *ListUserParams) ([]ConversationsV1User, error) {
-	response, err := c.StreamUser(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamUser(params)
 
 	records := make([]ConversationsV1User, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams User records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamUser(params *ListUserParams) (chan ConversationsV1User, error) {
+func (c *ApiService) StreamUser(params *ListUserParams) (chan ConversationsV1User, chan error) {
 	if params == nil {
 		params = &ListUserParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ConversationsV1User, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageUser(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamUser(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamUser(response *ListUserResponse, params *ListUserParams, recordChannel chan ConversationsV1User, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ConversationsV1User, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Users
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListUserResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Users
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListUserResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListUserResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListUserResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListUserResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/events/v1/sinks.go
+++ b/rest/events/v1/sinks.go
@@ -192,60 +192,70 @@ func (c *ApiService) PageSink(params *ListSinkParams, pageToken, pageNumber stri
 
 // Lists Sink records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSink(params *ListSinkParams) ([]EventsV1Sink, error) {
-	response, err := c.StreamSink(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamSink(params)
 
 	records := make([]EventsV1Sink, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Sink records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamSink(params *ListSinkParams) (chan EventsV1Sink, error) {
+func (c *ApiService) StreamSink(params *ListSinkParams) (chan EventsV1Sink, chan error) {
 	if params == nil {
 		params = &ListSinkParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan EventsV1Sink, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageSink(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamSink(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamSink(response *ListSinkResponse, params *ListSinkParams, recordChannel chan EventsV1Sink, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan EventsV1Sink, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Sinks
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListSinkResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Sinks
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListSinkResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListSinkResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListSinkResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListSinkResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/events/v1/subscriptions_subscribed_events.go
+++ b/rest/events/v1/subscriptions_subscribed_events.go
@@ -164,60 +164,70 @@ func (c *ApiService) PageSubscribedEvent(SubscriptionSid string, params *ListSub
 
 // Lists SubscribedEvent records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSubscribedEvent(SubscriptionSid string, params *ListSubscribedEventParams) ([]EventsV1SubscribedEvent, error) {
-	response, err := c.StreamSubscribedEvent(SubscriptionSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamSubscribedEvent(SubscriptionSid, params)
 
 	records := make([]EventsV1SubscribedEvent, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams SubscribedEvent records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamSubscribedEvent(SubscriptionSid string, params *ListSubscribedEventParams) (chan EventsV1SubscribedEvent, error) {
+func (c *ApiService) StreamSubscribedEvent(SubscriptionSid string, params *ListSubscribedEventParams) (chan EventsV1SubscribedEvent, chan error) {
 	if params == nil {
 		params = &ListSubscribedEventParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan EventsV1SubscribedEvent, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageSubscribedEvent(SubscriptionSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamSubscribedEvent(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamSubscribedEvent(response *ListSubscribedEventResponse, params *ListSubscribedEventParams, recordChannel chan EventsV1SubscribedEvent, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan EventsV1SubscribedEvent, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Types
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListSubscribedEventResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Types
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListSubscribedEventResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListSubscribedEventResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListSubscribedEventResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListSubscribedEventResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/events/v1/types.go
+++ b/rest/events/v1/types.go
@@ -104,60 +104,70 @@ func (c *ApiService) PageEventType(params *ListEventTypeParams, pageToken, pageN
 
 // Lists EventType records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListEventType(params *ListEventTypeParams) ([]EventsV1EventType, error) {
-	response, err := c.StreamEventType(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamEventType(params)
 
 	records := make([]EventsV1EventType, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams EventType records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamEventType(params *ListEventTypeParams) (chan EventsV1EventType, error) {
+func (c *ApiService) StreamEventType(params *ListEventTypeParams) (chan EventsV1EventType, chan error) {
 	if params == nil {
 		params = &ListEventTypeParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan EventsV1EventType, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageEventType(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamEventType(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamEventType(response *ListEventTypeResponse, params *ListEventTypeParams, recordChannel chan EventsV1EventType, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan EventsV1EventType, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Types
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListEventTypeResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Types
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListEventTypeResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListEventTypeResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListEventTypeResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListEventTypeResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/fax/v1/faxes.go
+++ b/rest/fax/v1/faxes.go
@@ -150,60 +150,70 @@ func (c *ApiService) PageFax(params *ListFaxParams, pageToken, pageNumber string
 
 // Lists Fax records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListFax(params *ListFaxParams) ([]FaxV1Fax, error) {
-	response, err := c.StreamFax(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamFax(params)
 
 	records := make([]FaxV1Fax, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Fax records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamFax(params *ListFaxParams) (chan FaxV1Fax, error) {
+func (c *ApiService) StreamFax(params *ListFaxParams) (chan FaxV1Fax, chan error) {
 	if params == nil {
 		params = &ListFaxParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan FaxV1Fax, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageFax(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamFax(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamFax(response *ListFaxResponse, params *ListFaxParams, recordChannel chan FaxV1Fax, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan FaxV1Fax, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Faxes
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListFaxResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Faxes
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListFaxResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListFaxResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListFaxResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListFaxResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/fax/v1/faxes_media.go
+++ b/rest/fax/v1/faxes_media.go
@@ -117,60 +117,70 @@ func (c *ApiService) PageFaxMedia(FaxSid string, params *ListFaxMediaParams, pag
 
 // Lists FaxMedia records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListFaxMedia(FaxSid string, params *ListFaxMediaParams) ([]FaxV1FaxMedia, error) {
-	response, err := c.StreamFaxMedia(FaxSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamFaxMedia(FaxSid, params)
 
 	records := make([]FaxV1FaxMedia, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams FaxMedia records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamFaxMedia(FaxSid string, params *ListFaxMediaParams) (chan FaxV1FaxMedia, error) {
+func (c *ApiService) StreamFaxMedia(FaxSid string, params *ListFaxMediaParams) (chan FaxV1FaxMedia, chan error) {
 	if params == nil {
 		params = &ListFaxMediaParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan FaxV1FaxMedia, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageFaxMedia(FaxSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamFaxMedia(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamFaxMedia(response *ListFaxMediaResponse, params *ListFaxMediaParams, recordChannel chan FaxV1FaxMedia, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan FaxV1FaxMedia, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Media
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListFaxMediaResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Media
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListFaxMediaResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListFaxMediaResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListFaxMediaResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListFaxMediaResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/flex/v1/channels.go
+++ b/rest/flex/v1/channels.go
@@ -228,60 +228,70 @@ func (c *ApiService) PageChannel(params *ListChannelParams, pageToken, pageNumbe
 
 // Lists Channel records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListChannel(params *ListChannelParams) ([]FlexV1Channel, error) {
-	response, err := c.StreamChannel(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamChannel(params)
 
 	records := make([]FlexV1Channel, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Channel records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamChannel(params *ListChannelParams) (chan FlexV1Channel, error) {
+func (c *ApiService) StreamChannel(params *ListChannelParams) (chan FlexV1Channel, chan error) {
 	if params == nil {
 		params = &ListChannelParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan FlexV1Channel, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageChannel(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamChannel(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamChannel(response *ListChannelResponse, params *ListChannelParams, recordChannel chan FlexV1Channel, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan FlexV1Channel, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.FlexChatChannels
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListChannelResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.FlexChatChannels
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListChannelResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListChannelResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListChannelResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListChannelResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/flex/v1/flex_flows.go
+++ b/rest/flex/v1/flex_flows.go
@@ -300,60 +300,70 @@ func (c *ApiService) PageFlexFlow(params *ListFlexFlowParams, pageToken, pageNum
 
 // Lists FlexFlow records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListFlexFlow(params *ListFlexFlowParams) ([]FlexV1FlexFlow, error) {
-	response, err := c.StreamFlexFlow(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamFlexFlow(params)
 
 	records := make([]FlexV1FlexFlow, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams FlexFlow records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamFlexFlow(params *ListFlexFlowParams) (chan FlexV1FlexFlow, error) {
+func (c *ApiService) StreamFlexFlow(params *ListFlexFlowParams) (chan FlexV1FlexFlow, chan error) {
 	if params == nil {
 		params = &ListFlexFlowParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan FlexV1FlexFlow, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageFlexFlow(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamFlexFlow(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamFlexFlow(response *ListFlexFlowResponse, params *ListFlexFlowParams, recordChannel chan FlexV1FlexFlow, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan FlexV1FlexFlow, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.FlexFlows
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListFlexFlowResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.FlexFlows
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListFlexFlowResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListFlexFlowResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListFlexFlowResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListFlexFlowResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/flex/v1/interactions_channels.go
+++ b/rest/flex/v1/interactions_channels.go
@@ -98,60 +98,70 @@ func (c *ApiService) PageInteractionChannel(InteractionSid string, params *ListI
 
 // Lists InteractionChannel records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListInteractionChannel(InteractionSid string, params *ListInteractionChannelParams) ([]FlexV1InteractionChannel, error) {
-	response, err := c.StreamInteractionChannel(InteractionSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamInteractionChannel(InteractionSid, params)
 
 	records := make([]FlexV1InteractionChannel, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams InteractionChannel records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamInteractionChannel(InteractionSid string, params *ListInteractionChannelParams) (chan FlexV1InteractionChannel, error) {
+func (c *ApiService) StreamInteractionChannel(InteractionSid string, params *ListInteractionChannelParams) (chan FlexV1InteractionChannel, chan error) {
 	if params == nil {
 		params = &ListInteractionChannelParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan FlexV1InteractionChannel, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageInteractionChannel(InteractionSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamInteractionChannel(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamInteractionChannel(response *ListInteractionChannelResponse, params *ListInteractionChannelParams, recordChannel chan FlexV1InteractionChannel, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan FlexV1InteractionChannel, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Channels
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListInteractionChannelResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Channels
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListInteractionChannelResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListInteractionChannelResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListInteractionChannelResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListInteractionChannelResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/flex/v1/interactions_channels_participants.go
+++ b/rest/flex/v1/interactions_channels_participants.go
@@ -129,60 +129,70 @@ func (c *ApiService) PageInteractionChannelParticipant(InteractionSid string, Ch
 
 // Lists InteractionChannelParticipant records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListInteractionChannelParticipant(InteractionSid string, ChannelSid string, params *ListInteractionChannelParticipantParams) ([]FlexV1InteractionChannelParticipant, error) {
-	response, err := c.StreamInteractionChannelParticipant(InteractionSid, ChannelSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamInteractionChannelParticipant(InteractionSid, ChannelSid, params)
 
 	records := make([]FlexV1InteractionChannelParticipant, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams InteractionChannelParticipant records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamInteractionChannelParticipant(InteractionSid string, ChannelSid string, params *ListInteractionChannelParticipantParams) (chan FlexV1InteractionChannelParticipant, error) {
+func (c *ApiService) StreamInteractionChannelParticipant(InteractionSid string, ChannelSid string, params *ListInteractionChannelParticipantParams) (chan FlexV1InteractionChannelParticipant, chan error) {
 	if params == nil {
 		params = &ListInteractionChannelParticipantParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan FlexV1InteractionChannelParticipant, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageInteractionChannelParticipant(InteractionSid, ChannelSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamInteractionChannelParticipant(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamInteractionChannelParticipant(response *ListInteractionChannelParticipantResponse, params *ListInteractionChannelParticipantParams, recordChannel chan FlexV1InteractionChannelParticipant, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan FlexV1InteractionChannelParticipant, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Participants
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListInteractionChannelParticipantResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Participants
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListInteractionChannelParticipantResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListInteractionChannelParticipantResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListInteractionChannelParticipantResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListInteractionChannelParticipantResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/flex/v1/web_channels.go
+++ b/rest/flex/v1/web_channels.go
@@ -192,60 +192,70 @@ func (c *ApiService) PageWebChannel(params *ListWebChannelParams, pageToken, pag
 
 // Lists WebChannel records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListWebChannel(params *ListWebChannelParams) ([]FlexV1WebChannel, error) {
-	response, err := c.StreamWebChannel(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamWebChannel(params)
 
 	records := make([]FlexV1WebChannel, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams WebChannel records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamWebChannel(params *ListWebChannelParams) (chan FlexV1WebChannel, error) {
+func (c *ApiService) StreamWebChannel(params *ListWebChannelParams) (chan FlexV1WebChannel, chan error) {
 	if params == nil {
 		params = &ListWebChannelParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan FlexV1WebChannel, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageWebChannel(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamWebChannel(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamWebChannel(response *ListWebChannelResponse, params *ListWebChannelParams, recordChannel chan FlexV1WebChannel, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan FlexV1WebChannel, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.FlexChatChannels
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListWebChannelResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.FlexChatChannels
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListWebChannelResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListWebChannelResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListWebChannelResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListWebChannelResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/insights/v1/conferences_participants.go
+++ b/rest/insights/v1/conferences_participants.go
@@ -149,60 +149,70 @@ func (c *ApiService) PageConferenceParticipant(ConferenceSid string, params *Lis
 
 // Lists ConferenceParticipant records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListConferenceParticipant(ConferenceSid string, params *ListConferenceParticipantParams) ([]InsightsV1ConferenceParticipant, error) {
-	response, err := c.StreamConferenceParticipant(ConferenceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamConferenceParticipant(ConferenceSid, params)
 
 	records := make([]InsightsV1ConferenceParticipant, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ConferenceParticipant records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamConferenceParticipant(ConferenceSid string, params *ListConferenceParticipantParams) (chan InsightsV1ConferenceParticipant, error) {
+func (c *ApiService) StreamConferenceParticipant(ConferenceSid string, params *ListConferenceParticipantParams) (chan InsightsV1ConferenceParticipant, chan error) {
 	if params == nil {
 		params = &ListConferenceParticipantParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan InsightsV1ConferenceParticipant, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageConferenceParticipant(ConferenceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamConferenceParticipant(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamConferenceParticipant(response *ListConferenceParticipantResponse, params *ListConferenceParticipantParams, recordChannel chan InsightsV1ConferenceParticipant, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan InsightsV1ConferenceParticipant, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Participants
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListConferenceParticipantResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Participants
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListConferenceParticipantResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListConferenceParticipantResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListConferenceParticipantResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListConferenceParticipantResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/insights/v1/video_rooms.go
+++ b/rest/insights/v1/video_rooms.go
@@ -145,60 +145,70 @@ func (c *ApiService) PageVideoRoomSummary(params *ListVideoRoomSummaryParams, pa
 
 // Lists VideoRoomSummary records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListVideoRoomSummary(params *ListVideoRoomSummaryParams) ([]InsightsV1VideoRoomSummary, error) {
-	response, err := c.StreamVideoRoomSummary(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamVideoRoomSummary(params)
 
 	records := make([]InsightsV1VideoRoomSummary, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams VideoRoomSummary records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamVideoRoomSummary(params *ListVideoRoomSummaryParams) (chan InsightsV1VideoRoomSummary, error) {
+func (c *ApiService) StreamVideoRoomSummary(params *ListVideoRoomSummaryParams) (chan InsightsV1VideoRoomSummary, chan error) {
 	if params == nil {
 		params = &ListVideoRoomSummaryParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan InsightsV1VideoRoomSummary, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageVideoRoomSummary(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamVideoRoomSummary(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamVideoRoomSummary(response *ListVideoRoomSummaryResponse, params *ListVideoRoomSummaryParams, recordChannel chan InsightsV1VideoRoomSummary, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan InsightsV1VideoRoomSummary, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Rooms
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListVideoRoomSummaryResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Rooms
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListVideoRoomSummaryResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListVideoRoomSummaryResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListVideoRoomSummaryResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListVideoRoomSummaryResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/insights/v1/video_rooms_participants.go
+++ b/rest/insights/v1/video_rooms_participants.go
@@ -98,60 +98,70 @@ func (c *ApiService) PageVideoParticipantSummary(RoomSid string, params *ListVid
 
 // Lists VideoParticipantSummary records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListVideoParticipantSummary(RoomSid string, params *ListVideoParticipantSummaryParams) ([]InsightsV1VideoParticipantSummary, error) {
-	response, err := c.StreamVideoParticipantSummary(RoomSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamVideoParticipantSummary(RoomSid, params)
 
 	records := make([]InsightsV1VideoParticipantSummary, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams VideoParticipantSummary records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamVideoParticipantSummary(RoomSid string, params *ListVideoParticipantSummaryParams) (chan InsightsV1VideoParticipantSummary, error) {
+func (c *ApiService) StreamVideoParticipantSummary(RoomSid string, params *ListVideoParticipantSummaryParams) (chan InsightsV1VideoParticipantSummary, chan error) {
 	if params == nil {
 		params = &ListVideoParticipantSummaryParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan InsightsV1VideoParticipantSummary, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageVideoParticipantSummary(RoomSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamVideoParticipantSummary(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamVideoParticipantSummary(response *ListVideoParticipantSummaryResponse, params *ListVideoParticipantSummaryParams, recordChannel chan InsightsV1VideoParticipantSummary, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan InsightsV1VideoParticipantSummary, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Participants
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListVideoParticipantSummaryResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Participants
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListVideoParticipantSummaryResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListVideoParticipantSummaryResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListVideoParticipantSummaryResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListVideoParticipantSummaryResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/insights/v1/voice_events.go
+++ b/rest/insights/v1/voice_events.go
@@ -83,60 +83,70 @@ func (c *ApiService) PageEvent(CallSid string, params *ListEventParams, pageToke
 
 // Lists Event records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListEvent(CallSid string, params *ListEventParams) ([]InsightsV1Event, error) {
-	response, err := c.StreamEvent(CallSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamEvent(CallSid, params)
 
 	records := make([]InsightsV1Event, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Event records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamEvent(CallSid string, params *ListEventParams) (chan InsightsV1Event, error) {
+func (c *ApiService) StreamEvent(CallSid string, params *ListEventParams) (chan InsightsV1Event, chan error) {
 	if params == nil {
 		params = &ListEventParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan InsightsV1Event, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageEvent(CallSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamEvent(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamEvent(response *ListEventResponse, params *ListEventParams, recordChannel chan InsightsV1Event, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan InsightsV1Event, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Events
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListEventResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Events
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListEventResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListEventResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListEventResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListEventResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/insights/v1/voice_metrics.go
+++ b/rest/insights/v1/voice_metrics.go
@@ -92,60 +92,70 @@ func (c *ApiService) PageMetric(CallSid string, params *ListMetricParams, pageTo
 
 // Lists Metric records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMetric(CallSid string, params *ListMetricParams) ([]InsightsV1Metric, error) {
-	response, err := c.StreamMetric(CallSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamMetric(CallSid, params)
 
 	records := make([]InsightsV1Metric, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Metric records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamMetric(CallSid string, params *ListMetricParams) (chan InsightsV1Metric, error) {
+func (c *ApiService) StreamMetric(CallSid string, params *ListMetricParams) (chan InsightsV1Metric, chan error) {
 	if params == nil {
 		params = &ListMetricParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan InsightsV1Metric, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageMetric(CallSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamMetric(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamMetric(response *ListMetricResponse, params *ListMetricParams, recordChannel chan InsightsV1Metric, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan InsightsV1Metric, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Metrics
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListMetricResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Metrics
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListMetricResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListMetricResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListMetricResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListMetricResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/insights/v1/voice_summaries.go
+++ b/rest/insights/v1/voice_summaries.go
@@ -233,60 +233,70 @@ func (c *ApiService) PageCallSummaries(params *ListCallSummariesParams, pageToke
 
 // Lists CallSummaries records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCallSummaries(params *ListCallSummariesParams) ([]InsightsV1CallSummaries, error) {
-	response, err := c.StreamCallSummaries(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamCallSummaries(params)
 
 	records := make([]InsightsV1CallSummaries, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams CallSummaries records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamCallSummaries(params *ListCallSummariesParams) (chan InsightsV1CallSummaries, error) {
+func (c *ApiService) StreamCallSummaries(params *ListCallSummariesParams) (chan InsightsV1CallSummaries, chan error) {
 	if params == nil {
 		params = &ListCallSummariesParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan InsightsV1CallSummaries, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageCallSummaries(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamCallSummaries(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamCallSummaries(response *ListCallSummariesResponse, params *ListCallSummariesParams, recordChannel chan InsightsV1CallSummaries, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan InsightsV1CallSummaries, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.CallSummaries
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListCallSummariesResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.CallSummaries
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListCallSummariesResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListCallSummariesResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListCallSummariesResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListCallSummariesResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/ip_messaging/v1/credentials.go
+++ b/rest/ip_messaging/v1/credentials.go
@@ -201,60 +201,70 @@ func (c *ApiService) PageCredential(params *ListCredentialParams, pageToken, pag
 
 // Lists Credential records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCredential(params *ListCredentialParams) ([]IpMessagingV1Credential, error) {
-	response, err := c.StreamCredential(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamCredential(params)
 
 	records := make([]IpMessagingV1Credential, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Credential records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamCredential(params *ListCredentialParams) (chan IpMessagingV1Credential, error) {
+func (c *ApiService) StreamCredential(params *ListCredentialParams) (chan IpMessagingV1Credential, chan error) {
 	if params == nil {
 		params = &ListCredentialParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan IpMessagingV1Credential, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageCredential(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamCredential(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamCredential(response *ListCredentialResponse, params *ListCredentialParams, recordChannel chan IpMessagingV1Credential, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan IpMessagingV1Credential, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Credentials
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListCredentialResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Credentials
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListCredentialResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListCredentialResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListCredentialResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListCredentialResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/ip_messaging/v1/services.go
+++ b/rest/ip_messaging/v1/services.go
@@ -147,60 +147,70 @@ func (c *ApiService) PageService(params *ListServiceParams, pageToken, pageNumbe
 
 // Lists Service records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListService(params *ListServiceParams) ([]IpMessagingV1Service, error) {
-	response, err := c.StreamService(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamService(params)
 
 	records := make([]IpMessagingV1Service, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Service records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamService(params *ListServiceParams) (chan IpMessagingV1Service, error) {
+func (c *ApiService) StreamService(params *ListServiceParams) (chan IpMessagingV1Service, chan error) {
 	if params == nil {
 		params = &ListServiceParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan IpMessagingV1Service, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageService(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamService(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamService(response *ListServiceResponse, params *ListServiceParams, recordChannel chan IpMessagingV1Service, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan IpMessagingV1Service, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Services
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Services
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListServiceResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListServiceResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListServiceResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListServiceResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/ip_messaging/v1/services_channels.go
+++ b/rest/ip_messaging/v1/services_channels.go
@@ -190,60 +190,70 @@ func (c *ApiService) PageChannel(ServiceSid string, params *ListChannelParams, p
 
 // Lists Channel records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListChannel(ServiceSid string, params *ListChannelParams) ([]IpMessagingV1Channel, error) {
-	response, err := c.StreamChannel(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamChannel(ServiceSid, params)
 
 	records := make([]IpMessagingV1Channel, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Channel records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamChannel(ServiceSid string, params *ListChannelParams) (chan IpMessagingV1Channel, error) {
+func (c *ApiService) StreamChannel(ServiceSid string, params *ListChannelParams) (chan IpMessagingV1Channel, chan error) {
 	if params == nil {
 		params = &ListChannelParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan IpMessagingV1Channel, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageChannel(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamChannel(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamChannel(response *ListChannelResponse, params *ListChannelParams, recordChannel chan IpMessagingV1Channel, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan IpMessagingV1Channel, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Channels
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListChannelResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Channels
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListChannelResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListChannelResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListChannelResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListChannelResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/ip_messaging/v1/services_channels_invites.go
+++ b/rest/ip_messaging/v1/services_channels_invites.go
@@ -176,60 +176,70 @@ func (c *ApiService) PageInvite(ServiceSid string, ChannelSid string, params *Li
 
 // Lists Invite records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListInvite(ServiceSid string, ChannelSid string, params *ListInviteParams) ([]IpMessagingV1Invite, error) {
-	response, err := c.StreamInvite(ServiceSid, ChannelSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamInvite(ServiceSid, ChannelSid, params)
 
 	records := make([]IpMessagingV1Invite, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Invite records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamInvite(ServiceSid string, ChannelSid string, params *ListInviteParams) (chan IpMessagingV1Invite, error) {
+func (c *ApiService) StreamInvite(ServiceSid string, ChannelSid string, params *ListInviteParams) (chan IpMessagingV1Invite, chan error) {
 	if params == nil {
 		params = &ListInviteParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan IpMessagingV1Invite, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageInvite(ServiceSid, ChannelSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamInvite(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamInvite(response *ListInviteResponse, params *ListInviteParams, recordChannel chan IpMessagingV1Invite, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan IpMessagingV1Invite, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Invites
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListInviteResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Invites
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListInviteResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListInviteResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListInviteResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListInviteResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/ip_messaging/v1/services_channels_members.go
+++ b/rest/ip_messaging/v1/services_channels_members.go
@@ -176,60 +176,70 @@ func (c *ApiService) PageMember(ServiceSid string, ChannelSid string, params *Li
 
 // Lists Member records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMember(ServiceSid string, ChannelSid string, params *ListMemberParams) ([]IpMessagingV1Member, error) {
-	response, err := c.StreamMember(ServiceSid, ChannelSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamMember(ServiceSid, ChannelSid, params)
 
 	records := make([]IpMessagingV1Member, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Member records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamMember(ServiceSid string, ChannelSid string, params *ListMemberParams) (chan IpMessagingV1Member, error) {
+func (c *ApiService) StreamMember(ServiceSid string, ChannelSid string, params *ListMemberParams) (chan IpMessagingV1Member, chan error) {
 	if params == nil {
 		params = &ListMemberParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan IpMessagingV1Member, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageMember(ServiceSid, ChannelSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamMember(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamMember(response *ListMemberResponse, params *ListMemberParams, recordChannel chan IpMessagingV1Member, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan IpMessagingV1Member, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Members
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListMemberResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Members
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListMemberResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListMemberResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListMemberResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListMemberResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/ip_messaging/v1/services_channels_messages.go
+++ b/rest/ip_messaging/v1/services_channels_messages.go
@@ -183,60 +183,70 @@ func (c *ApiService) PageMessage(ServiceSid string, ChannelSid string, params *L
 
 // Lists Message records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMessage(ServiceSid string, ChannelSid string, params *ListMessageParams) ([]IpMessagingV1Message, error) {
-	response, err := c.StreamMessage(ServiceSid, ChannelSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamMessage(ServiceSid, ChannelSid, params)
 
 	records := make([]IpMessagingV1Message, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Message records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamMessage(ServiceSid string, ChannelSid string, params *ListMessageParams) (chan IpMessagingV1Message, error) {
+func (c *ApiService) StreamMessage(ServiceSid string, ChannelSid string, params *ListMessageParams) (chan IpMessagingV1Message, chan error) {
 	if params == nil {
 		params = &ListMessageParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan IpMessagingV1Message, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageMessage(ServiceSid, ChannelSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamMessage(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamMessage(response *ListMessageResponse, params *ListMessageParams, recordChannel chan IpMessagingV1Message, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan IpMessagingV1Message, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Messages
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListMessageResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Messages
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListMessageResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListMessageResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListMessageResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListMessageResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/ip_messaging/v1/services_roles.go
+++ b/rest/ip_messaging/v1/services_roles.go
@@ -172,60 +172,70 @@ func (c *ApiService) PageRole(ServiceSid string, params *ListRoleParams, pageTok
 
 // Lists Role records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRole(ServiceSid string, params *ListRoleParams) ([]IpMessagingV1Role, error) {
-	response, err := c.StreamRole(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamRole(ServiceSid, params)
 
 	records := make([]IpMessagingV1Role, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Role records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamRole(ServiceSid string, params *ListRoleParams) (chan IpMessagingV1Role, error) {
+func (c *ApiService) StreamRole(ServiceSid string, params *ListRoleParams) (chan IpMessagingV1Role, chan error) {
 	if params == nil {
 		params = &ListRoleParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan IpMessagingV1Role, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageRole(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamRole(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamRole(response *ListRoleResponse, params *ListRoleParams, recordChannel chan IpMessagingV1Role, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan IpMessagingV1Role, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Roles
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListRoleResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Roles
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListRoleResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListRoleResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListRoleResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListRoleResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/ip_messaging/v1/services_users.go
+++ b/rest/ip_messaging/v1/services_users.go
@@ -179,60 +179,70 @@ func (c *ApiService) PageUser(ServiceSid string, params *ListUserParams, pageTok
 
 // Lists User records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUser(ServiceSid string, params *ListUserParams) ([]IpMessagingV1User, error) {
-	response, err := c.StreamUser(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamUser(ServiceSid, params)
 
 	records := make([]IpMessagingV1User, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams User records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamUser(ServiceSid string, params *ListUserParams) (chan IpMessagingV1User, error) {
+func (c *ApiService) StreamUser(ServiceSid string, params *ListUserParams) (chan IpMessagingV1User, chan error) {
 	if params == nil {
 		params = &ListUserParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan IpMessagingV1User, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageUser(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamUser(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamUser(response *ListUserResponse, params *ListUserParams, recordChannel chan IpMessagingV1User, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan IpMessagingV1User, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Users
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListUserResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Users
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListUserResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListUserResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListUserResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListUserResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/ip_messaging/v1/services_users_channels.go
+++ b/rest/ip_messaging/v1/services_users_channels.go
@@ -75,60 +75,70 @@ func (c *ApiService) PageUserChannel(ServiceSid string, UserSid string, params *
 
 // Lists UserChannel records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUserChannel(ServiceSid string, UserSid string, params *ListUserChannelParams) ([]IpMessagingV1UserChannel, error) {
-	response, err := c.StreamUserChannel(ServiceSid, UserSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamUserChannel(ServiceSid, UserSid, params)
 
 	records := make([]IpMessagingV1UserChannel, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams UserChannel records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamUserChannel(ServiceSid string, UserSid string, params *ListUserChannelParams) (chan IpMessagingV1UserChannel, error) {
+func (c *ApiService) StreamUserChannel(ServiceSid string, UserSid string, params *ListUserChannelParams) (chan IpMessagingV1UserChannel, chan error) {
 	if params == nil {
 		params = &ListUserChannelParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan IpMessagingV1UserChannel, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageUserChannel(ServiceSid, UserSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamUserChannel(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamUserChannel(response *ListUserChannelResponse, params *ListUserChannelParams, recordChannel chan IpMessagingV1UserChannel, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan IpMessagingV1UserChannel, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Channels
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListUserChannelResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Channels
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListUserChannelResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListUserChannelResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListUserChannelResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListUserChannelResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/ip_messaging/v2/services.go
+++ b/rest/ip_messaging/v2/services.go
@@ -147,60 +147,70 @@ func (c *ApiService) PageService(params *ListServiceParams, pageToken, pageNumbe
 
 // Lists Service records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListService(params *ListServiceParams) ([]IpMessagingV2Service, error) {
-	response, err := c.StreamService(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamService(params)
 
 	records := make([]IpMessagingV2Service, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Service records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamService(params *ListServiceParams) (chan IpMessagingV2Service, error) {
+func (c *ApiService) StreamService(params *ListServiceParams) (chan IpMessagingV2Service, chan error) {
 	if params == nil {
 		params = &ListServiceParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan IpMessagingV2Service, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageService(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamService(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamService(response *ListServiceResponse, params *ListServiceParams, recordChannel chan IpMessagingV2Service, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan IpMessagingV2Service, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Services
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Services
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListServiceResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListServiceResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListServiceResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListServiceResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/ip_messaging/v2/services_bindings.go
+++ b/rest/ip_messaging/v2/services_bindings.go
@@ -137,60 +137,70 @@ func (c *ApiService) PageBinding(ServiceSid string, params *ListBindingParams, p
 
 // Lists Binding records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListBinding(ServiceSid string, params *ListBindingParams) ([]IpMessagingV2Binding, error) {
-	response, err := c.StreamBinding(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamBinding(ServiceSid, params)
 
 	records := make([]IpMessagingV2Binding, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Binding records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamBinding(ServiceSid string, params *ListBindingParams) (chan IpMessagingV2Binding, error) {
+func (c *ApiService) StreamBinding(ServiceSid string, params *ListBindingParams) (chan IpMessagingV2Binding, chan error) {
 	if params == nil {
 		params = &ListBindingParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan IpMessagingV2Binding, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageBinding(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamBinding(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamBinding(response *ListBindingResponse, params *ListBindingParams, recordChannel chan IpMessagingV2Binding, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan IpMessagingV2Binding, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Bindings
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListBindingResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Bindings
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListBindingResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListBindingResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListBindingResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListBindingResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/ip_messaging/v2/services_channels.go
+++ b/rest/ip_messaging/v2/services_channels.go
@@ -243,60 +243,70 @@ func (c *ApiService) PageChannel(ServiceSid string, params *ListChannelParams, p
 
 // Lists Channel records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListChannel(ServiceSid string, params *ListChannelParams) ([]IpMessagingV2Channel, error) {
-	response, err := c.StreamChannel(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamChannel(ServiceSid, params)
 
 	records := make([]IpMessagingV2Channel, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Channel records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamChannel(ServiceSid string, params *ListChannelParams) (chan IpMessagingV2Channel, error) {
+func (c *ApiService) StreamChannel(ServiceSid string, params *ListChannelParams) (chan IpMessagingV2Channel, chan error) {
 	if params == nil {
 		params = &ListChannelParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan IpMessagingV2Channel, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageChannel(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamChannel(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamChannel(response *ListChannelResponse, params *ListChannelParams, recordChannel chan IpMessagingV2Channel, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan IpMessagingV2Channel, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Channels
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListChannelResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Channels
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListChannelResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListChannelResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListChannelResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListChannelResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/ip_messaging/v2/services_channels_invites.go
+++ b/rest/ip_messaging/v2/services_channels_invites.go
@@ -176,60 +176,70 @@ func (c *ApiService) PageInvite(ServiceSid string, ChannelSid string, params *Li
 
 // Lists Invite records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListInvite(ServiceSid string, ChannelSid string, params *ListInviteParams) ([]IpMessagingV2Invite, error) {
-	response, err := c.StreamInvite(ServiceSid, ChannelSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamInvite(ServiceSid, ChannelSid, params)
 
 	records := make([]IpMessagingV2Invite, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Invite records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamInvite(ServiceSid string, ChannelSid string, params *ListInviteParams) (chan IpMessagingV2Invite, error) {
+func (c *ApiService) StreamInvite(ServiceSid string, ChannelSid string, params *ListInviteParams) (chan IpMessagingV2Invite, chan error) {
 	if params == nil {
 		params = &ListInviteParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan IpMessagingV2Invite, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageInvite(ServiceSid, ChannelSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamInvite(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamInvite(response *ListInviteResponse, params *ListInviteParams, recordChannel chan IpMessagingV2Invite, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan IpMessagingV2Invite, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Invites
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListInviteResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Invites
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListInviteResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListInviteResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListInviteResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListInviteResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/ip_messaging/v2/services_channels_members.go
+++ b/rest/ip_messaging/v2/services_channels_members.go
@@ -247,60 +247,70 @@ func (c *ApiService) PageMember(ServiceSid string, ChannelSid string, params *Li
 
 // Lists Member records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMember(ServiceSid string, ChannelSid string, params *ListMemberParams) ([]IpMessagingV2Member, error) {
-	response, err := c.StreamMember(ServiceSid, ChannelSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamMember(ServiceSid, ChannelSid, params)
 
 	records := make([]IpMessagingV2Member, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Member records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamMember(ServiceSid string, ChannelSid string, params *ListMemberParams) (chan IpMessagingV2Member, error) {
+func (c *ApiService) StreamMember(ServiceSid string, ChannelSid string, params *ListMemberParams) (chan IpMessagingV2Member, chan error) {
 	if params == nil {
 		params = &ListMemberParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan IpMessagingV2Member, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageMember(ServiceSid, ChannelSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamMember(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamMember(response *ListMemberResponse, params *ListMemberParams, recordChannel chan IpMessagingV2Member, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan IpMessagingV2Member, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Members
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListMemberResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Members
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListMemberResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListMemberResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListMemberResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListMemberResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/ip_messaging/v2/services_channels_webhooks.go
+++ b/rest/ip_messaging/v2/services_channels_webhooks.go
@@ -214,60 +214,70 @@ func (c *ApiService) PageChannelWebhook(ServiceSid string, ChannelSid string, pa
 
 // Lists ChannelWebhook records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListChannelWebhook(ServiceSid string, ChannelSid string, params *ListChannelWebhookParams) ([]IpMessagingV2ChannelWebhook, error) {
-	response, err := c.StreamChannelWebhook(ServiceSid, ChannelSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamChannelWebhook(ServiceSid, ChannelSid, params)
 
 	records := make([]IpMessagingV2ChannelWebhook, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ChannelWebhook records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamChannelWebhook(ServiceSid string, ChannelSid string, params *ListChannelWebhookParams) (chan IpMessagingV2ChannelWebhook, error) {
+func (c *ApiService) StreamChannelWebhook(ServiceSid string, ChannelSid string, params *ListChannelWebhookParams) (chan IpMessagingV2ChannelWebhook, chan error) {
 	if params == nil {
 		params = &ListChannelWebhookParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan IpMessagingV2ChannelWebhook, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageChannelWebhook(ServiceSid, ChannelSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamChannelWebhook(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamChannelWebhook(response *ListChannelWebhookResponse, params *ListChannelWebhookParams, recordChannel chan IpMessagingV2ChannelWebhook, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan IpMessagingV2ChannelWebhook, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Webhooks
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListChannelWebhookResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Webhooks
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListChannelWebhookResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListChannelWebhookResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListChannelWebhookResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListChannelWebhookResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/ip_messaging/v2/services_roles.go
+++ b/rest/ip_messaging/v2/services_roles.go
@@ -172,60 +172,70 @@ func (c *ApiService) PageRole(ServiceSid string, params *ListRoleParams, pageTok
 
 // Lists Role records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRole(ServiceSid string, params *ListRoleParams) ([]IpMessagingV2Role, error) {
-	response, err := c.StreamRole(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamRole(ServiceSid, params)
 
 	records := make([]IpMessagingV2Role, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Role records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamRole(ServiceSid string, params *ListRoleParams) (chan IpMessagingV2Role, error) {
+func (c *ApiService) StreamRole(ServiceSid string, params *ListRoleParams) (chan IpMessagingV2Role, chan error) {
 	if params == nil {
 		params = &ListRoleParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan IpMessagingV2Role, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageRole(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamRole(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamRole(response *ListRoleResponse, params *ListRoleParams, recordChannel chan IpMessagingV2Role, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan IpMessagingV2Role, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Roles
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListRoleResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Roles
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListRoleResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListRoleResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListRoleResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListRoleResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/ip_messaging/v2/services_users.go
+++ b/rest/ip_messaging/v2/services_users.go
@@ -189,60 +189,70 @@ func (c *ApiService) PageUser(ServiceSid string, params *ListUserParams, pageTok
 
 // Lists User records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUser(ServiceSid string, params *ListUserParams) ([]IpMessagingV2User, error) {
-	response, err := c.StreamUser(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamUser(ServiceSid, params)
 
 	records := make([]IpMessagingV2User, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams User records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamUser(ServiceSid string, params *ListUserParams) (chan IpMessagingV2User, error) {
+func (c *ApiService) StreamUser(ServiceSid string, params *ListUserParams) (chan IpMessagingV2User, chan error) {
 	if params == nil {
 		params = &ListUserParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan IpMessagingV2User, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageUser(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamUser(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamUser(response *ListUserResponse, params *ListUserParams, recordChannel chan IpMessagingV2User, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan IpMessagingV2User, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Users
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListUserResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Users
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListUserResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListUserResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListUserResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListUserResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/ip_messaging/v2/services_users_channels.go
+++ b/rest/ip_messaging/v2/services_users_channels.go
@@ -119,60 +119,70 @@ func (c *ApiService) PageUserChannel(ServiceSid string, UserSid string, params *
 
 // Lists UserChannel records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUserChannel(ServiceSid string, UserSid string, params *ListUserChannelParams) ([]IpMessagingV2UserChannel, error) {
-	response, err := c.StreamUserChannel(ServiceSid, UserSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamUserChannel(ServiceSid, UserSid, params)
 
 	records := make([]IpMessagingV2UserChannel, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams UserChannel records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamUserChannel(ServiceSid string, UserSid string, params *ListUserChannelParams) (chan IpMessagingV2UserChannel, error) {
+func (c *ApiService) StreamUserChannel(ServiceSid string, UserSid string, params *ListUserChannelParams) (chan IpMessagingV2UserChannel, chan error) {
 	if params == nil {
 		params = &ListUserChannelParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan IpMessagingV2UserChannel, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageUserChannel(ServiceSid, UserSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamUserChannel(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamUserChannel(response *ListUserChannelResponse, params *ListUserChannelParams, recordChannel chan IpMessagingV2UserChannel, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan IpMessagingV2UserChannel, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Channels
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListUserChannelResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Channels
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListUserChannelResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListUserChannelResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListUserChannelResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListUserChannelResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/media/v1/media_processors.go
+++ b/rest/media/v1/media_processors.go
@@ -200,60 +200,70 @@ func (c *ApiService) PageMediaProcessor(params *ListMediaProcessorParams, pageTo
 
 // Lists MediaProcessor records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMediaProcessor(params *ListMediaProcessorParams) ([]MediaV1MediaProcessor, error) {
-	response, err := c.StreamMediaProcessor(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamMediaProcessor(params)
 
 	records := make([]MediaV1MediaProcessor, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams MediaProcessor records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamMediaProcessor(params *ListMediaProcessorParams) (chan MediaV1MediaProcessor, error) {
+func (c *ApiService) StreamMediaProcessor(params *ListMediaProcessorParams) (chan MediaV1MediaProcessor, chan error) {
 	if params == nil {
 		params = &ListMediaProcessorParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan MediaV1MediaProcessor, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageMediaProcessor(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamMediaProcessor(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamMediaProcessor(response *ListMediaProcessorResponse, params *ListMediaProcessorParams, recordChannel chan MediaV1MediaProcessor, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan MediaV1MediaProcessor, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.MediaProcessors
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListMediaProcessorResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.MediaProcessors
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListMediaProcessorResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListMediaProcessorResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListMediaProcessorResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListMediaProcessorResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/media/v1/media_recordings.go
+++ b/rest/media/v1/media_recordings.go
@@ -149,60 +149,70 @@ func (c *ApiService) PageMediaRecording(params *ListMediaRecordingParams, pageTo
 
 // Lists MediaRecording records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMediaRecording(params *ListMediaRecordingParams) ([]MediaV1MediaRecording, error) {
-	response, err := c.StreamMediaRecording(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamMediaRecording(params)
 
 	records := make([]MediaV1MediaRecording, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams MediaRecording records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamMediaRecording(params *ListMediaRecordingParams) (chan MediaV1MediaRecording, error) {
+func (c *ApiService) StreamMediaRecording(params *ListMediaRecordingParams) (chan MediaV1MediaRecording, chan error) {
 	if params == nil {
 		params = &ListMediaRecordingParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan MediaV1MediaRecording, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageMediaRecording(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamMediaRecording(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamMediaRecording(response *ListMediaRecordingResponse, params *ListMediaRecordingParams, recordChannel chan MediaV1MediaRecording, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan MediaV1MediaRecording, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.MediaRecordings
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListMediaRecordingResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.MediaRecordings
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListMediaRecordingResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListMediaRecordingResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListMediaRecordingResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListMediaRecordingResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/media/v1/player_streamers.go
+++ b/rest/media/v1/player_streamers.go
@@ -176,60 +176,70 @@ func (c *ApiService) PagePlayerStreamer(params *ListPlayerStreamerParams, pageTo
 
 // Lists PlayerStreamer records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListPlayerStreamer(params *ListPlayerStreamerParams) ([]MediaV1PlayerStreamer, error) {
-	response, err := c.StreamPlayerStreamer(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamPlayerStreamer(params)
 
 	records := make([]MediaV1PlayerStreamer, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams PlayerStreamer records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamPlayerStreamer(params *ListPlayerStreamerParams) (chan MediaV1PlayerStreamer, error) {
+func (c *ApiService) StreamPlayerStreamer(params *ListPlayerStreamerParams) (chan MediaV1PlayerStreamer, chan error) {
 	if params == nil {
 		params = &ListPlayerStreamerParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan MediaV1PlayerStreamer, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PagePlayerStreamer(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamPlayerStreamer(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamPlayerStreamer(response *ListPlayerStreamerResponse, params *ListPlayerStreamerParams, recordChannel chan MediaV1PlayerStreamer, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan MediaV1PlayerStreamer, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.PlayerStreamers
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListPlayerStreamerResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.PlayerStreamers
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListPlayerStreamerResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListPlayerStreamerResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListPlayerStreamerResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListPlayerStreamerResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/messaging/v1/a2p_brand_registrations.go
+++ b/rest/messaging/v1/a2p_brand_registrations.go
@@ -166,60 +166,70 @@ func (c *ApiService) PageBrandRegistrations(params *ListBrandRegistrationsParams
 
 // Lists BrandRegistrations records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListBrandRegistrations(params *ListBrandRegistrationsParams) ([]MessagingV1BrandRegistrations, error) {
-	response, err := c.StreamBrandRegistrations(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamBrandRegistrations(params)
 
 	records := make([]MessagingV1BrandRegistrations, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams BrandRegistrations records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamBrandRegistrations(params *ListBrandRegistrationsParams) (chan MessagingV1BrandRegistrations, error) {
+func (c *ApiService) StreamBrandRegistrations(params *ListBrandRegistrationsParams) (chan MessagingV1BrandRegistrations, chan error) {
 	if params == nil {
 		params = &ListBrandRegistrationsParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan MessagingV1BrandRegistrations, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageBrandRegistrations(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamBrandRegistrations(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamBrandRegistrations(response *ListBrandRegistrationsResponse, params *ListBrandRegistrationsParams, recordChannel chan MessagingV1BrandRegistrations, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan MessagingV1BrandRegistrations, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Data
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListBrandRegistrationsResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Data
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListBrandRegistrationsResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListBrandRegistrationsResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListBrandRegistrationsResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListBrandRegistrationsResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/messaging/v1/a2p_brand_registrations_vettings.go
+++ b/rest/messaging/v1/a2p_brand_registrations_vettings.go
@@ -152,60 +152,70 @@ func (c *ApiService) PageBrandVetting(BrandSid string, params *ListBrandVettingP
 
 // Lists BrandVetting records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListBrandVetting(BrandSid string, params *ListBrandVettingParams) ([]MessagingV1BrandVetting, error) {
-	response, err := c.StreamBrandVetting(BrandSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamBrandVetting(BrandSid, params)
 
 	records := make([]MessagingV1BrandVetting, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams BrandVetting records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamBrandVetting(BrandSid string, params *ListBrandVettingParams) (chan MessagingV1BrandVetting, error) {
+func (c *ApiService) StreamBrandVetting(BrandSid string, params *ListBrandVettingParams) (chan MessagingV1BrandVetting, chan error) {
 	if params == nil {
 		params = &ListBrandVettingParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan MessagingV1BrandVetting, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageBrandVetting(BrandSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamBrandVetting(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamBrandVetting(response *ListBrandVettingResponse, params *ListBrandVettingParams, recordChannel chan MessagingV1BrandVetting, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan MessagingV1BrandVetting, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Data
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListBrandVettingResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Data
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListBrandVettingResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListBrandVettingResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListBrandVettingResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListBrandVettingResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/messaging/v1/services.go
+++ b/rest/messaging/v1/services.go
@@ -282,60 +282,70 @@ func (c *ApiService) PageService(params *ListServiceParams, pageToken, pageNumbe
 
 // Lists Service records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListService(params *ListServiceParams) ([]MessagingV1Service, error) {
-	response, err := c.StreamService(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamService(params)
 
 	records := make([]MessagingV1Service, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Service records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamService(params *ListServiceParams) (chan MessagingV1Service, error) {
+func (c *ApiService) StreamService(params *ListServiceParams) (chan MessagingV1Service, chan error) {
 	if params == nil {
 		params = &ListServiceParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan MessagingV1Service, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageService(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamService(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamService(response *ListServiceResponse, params *ListServiceParams, recordChannel chan MessagingV1Service, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan MessagingV1Service, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Services
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Services
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListServiceResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListServiceResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListServiceResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListServiceResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/messaging/v1/services_alpha_senders.go
+++ b/rest/messaging/v1/services_alpha_senders.go
@@ -152,60 +152,70 @@ func (c *ApiService) PageAlphaSender(ServiceSid string, params *ListAlphaSenderP
 
 // Lists AlphaSender records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListAlphaSender(ServiceSid string, params *ListAlphaSenderParams) ([]MessagingV1AlphaSender, error) {
-	response, err := c.StreamAlphaSender(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamAlphaSender(ServiceSid, params)
 
 	records := make([]MessagingV1AlphaSender, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams AlphaSender records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamAlphaSender(ServiceSid string, params *ListAlphaSenderParams) (chan MessagingV1AlphaSender, error) {
+func (c *ApiService) StreamAlphaSender(ServiceSid string, params *ListAlphaSenderParams) (chan MessagingV1AlphaSender, chan error) {
 	if params == nil {
 		params = &ListAlphaSenderParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan MessagingV1AlphaSender, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageAlphaSender(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamAlphaSender(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamAlphaSender(response *ListAlphaSenderResponse, params *ListAlphaSenderParams, recordChannel chan MessagingV1AlphaSender, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan MessagingV1AlphaSender, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.AlphaSenders
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListAlphaSenderResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.AlphaSenders
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListAlphaSenderResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListAlphaSenderResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListAlphaSenderResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListAlphaSenderResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/messaging/v1/services_compliance_usa2p.go
+++ b/rest/messaging/v1/services_compliance_usa2p.go
@@ -199,60 +199,70 @@ func (c *ApiService) PageUsAppToPerson(MessagingServiceSid string, params *ListU
 
 // Lists UsAppToPerson records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUsAppToPerson(MessagingServiceSid string, params *ListUsAppToPersonParams) ([]MessagingV1UsAppToPerson, error) {
-	response, err := c.StreamUsAppToPerson(MessagingServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamUsAppToPerson(MessagingServiceSid, params)
 
 	records := make([]MessagingV1UsAppToPerson, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams UsAppToPerson records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamUsAppToPerson(MessagingServiceSid string, params *ListUsAppToPersonParams) (chan MessagingV1UsAppToPerson, error) {
+func (c *ApiService) StreamUsAppToPerson(MessagingServiceSid string, params *ListUsAppToPersonParams) (chan MessagingV1UsAppToPerson, chan error) {
 	if params == nil {
 		params = &ListUsAppToPersonParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan MessagingV1UsAppToPerson, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageUsAppToPerson(MessagingServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamUsAppToPerson(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamUsAppToPerson(response *ListUsAppToPersonResponse, params *ListUsAppToPersonParams, recordChannel chan MessagingV1UsAppToPerson, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan MessagingV1UsAppToPerson, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Compliance
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListUsAppToPersonResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Compliance
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListUsAppToPersonResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListUsAppToPersonResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListUsAppToPersonResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListUsAppToPersonResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/messaging/v1/services_short_codes.go
+++ b/rest/messaging/v1/services_short_codes.go
@@ -152,60 +152,70 @@ func (c *ApiService) PageShortCode(ServiceSid string, params *ListShortCodeParam
 
 // Lists ShortCode records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListShortCode(ServiceSid string, params *ListShortCodeParams) ([]MessagingV1ShortCode, error) {
-	response, err := c.StreamShortCode(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamShortCode(ServiceSid, params)
 
 	records := make([]MessagingV1ShortCode, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ShortCode records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamShortCode(ServiceSid string, params *ListShortCodeParams) (chan MessagingV1ShortCode, error) {
+func (c *ApiService) StreamShortCode(ServiceSid string, params *ListShortCodeParams) (chan MessagingV1ShortCode, chan error) {
 	if params == nil {
 		params = &ListShortCodeParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan MessagingV1ShortCode, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageShortCode(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamShortCode(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamShortCode(response *ListShortCodeResponse, params *ListShortCodeParams, recordChannel chan MessagingV1ShortCode, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan MessagingV1ShortCode, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.ShortCodes
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListShortCodeResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.ShortCodes
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListShortCodeResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListShortCodeResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListShortCodeResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListShortCodeResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/monitor/v1/alerts.go
+++ b/rest/monitor/v1/alerts.go
@@ -122,60 +122,70 @@ func (c *ApiService) PageAlert(params *ListAlertParams, pageToken, pageNumber st
 
 // Lists Alert records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListAlert(params *ListAlertParams) ([]MonitorV1Alert, error) {
-	response, err := c.StreamAlert(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamAlert(params)
 
 	records := make([]MonitorV1Alert, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Alert records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamAlert(params *ListAlertParams) (chan MonitorV1Alert, error) {
+func (c *ApiService) StreamAlert(params *ListAlertParams) (chan MonitorV1Alert, chan error) {
 	if params == nil {
 		params = &ListAlertParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan MonitorV1Alert, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageAlert(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamAlert(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamAlert(response *ListAlertResponse, params *ListAlertParams, recordChannel chan MonitorV1Alert, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan MonitorV1Alert, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Alerts
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListAlertResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Alerts
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListAlertResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListAlertResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListAlertResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListAlertResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/notify/v1/credentials.go
+++ b/rest/notify/v1/credentials.go
@@ -201,60 +201,70 @@ func (c *ApiService) PageCredential(params *ListCredentialParams, pageToken, pag
 
 // Lists Credential records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCredential(params *ListCredentialParams) ([]NotifyV1Credential, error) {
-	response, err := c.StreamCredential(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamCredential(params)
 
 	records := make([]NotifyV1Credential, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Credential records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamCredential(params *ListCredentialParams) (chan NotifyV1Credential, error) {
+func (c *ApiService) StreamCredential(params *ListCredentialParams) (chan NotifyV1Credential, chan error) {
 	if params == nil {
 		params = &ListCredentialParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan NotifyV1Credential, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageCredential(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamCredential(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamCredential(response *ListCredentialResponse, params *ListCredentialParams, recordChannel chan NotifyV1Credential, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan NotifyV1Credential, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Credentials
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListCredentialResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Credentials
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListCredentialResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListCredentialResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListCredentialResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListCredentialResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/notify/v1/services.go
+++ b/rest/notify/v1/services.go
@@ -273,60 +273,70 @@ func (c *ApiService) PageService(params *ListServiceParams, pageToken, pageNumbe
 
 // Lists Service records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListService(params *ListServiceParams) ([]NotifyV1Service, error) {
-	response, err := c.StreamService(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamService(params)
 
 	records := make([]NotifyV1Service, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Service records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamService(params *ListServiceParams) (chan NotifyV1Service, error) {
+func (c *ApiService) StreamService(params *ListServiceParams) (chan NotifyV1Service, chan error) {
 	if params == nil {
 		params = &ListServiceParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan NotifyV1Service, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageService(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamService(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamService(response *ListServiceResponse, params *ListServiceParams, recordChannel chan NotifyV1Service, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan NotifyV1Service, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Services
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Services
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListServiceResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListServiceResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListServiceResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListServiceResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/notify/v1/services_bindings.go
+++ b/rest/notify/v1/services_bindings.go
@@ -248,60 +248,70 @@ func (c *ApiService) PageBinding(ServiceSid string, params *ListBindingParams, p
 
 // Lists Binding records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListBinding(ServiceSid string, params *ListBindingParams) ([]NotifyV1Binding, error) {
-	response, err := c.StreamBinding(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamBinding(ServiceSid, params)
 
 	records := make([]NotifyV1Binding, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Binding records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamBinding(ServiceSid string, params *ListBindingParams) (chan NotifyV1Binding, error) {
+func (c *ApiService) StreamBinding(ServiceSid string, params *ListBindingParams) (chan NotifyV1Binding, chan error) {
 	if params == nil {
 		params = &ListBindingParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan NotifyV1Binding, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageBinding(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamBinding(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamBinding(response *ListBindingResponse, params *ListBindingParams, recordChannel chan NotifyV1Binding, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan NotifyV1Binding, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Bindings
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListBindingResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Bindings
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListBindingResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListBindingResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListBindingResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListBindingResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/numbers/v2/regulatory_compliance_bundles.go
+++ b/rest/numbers/v2/regulatory_compliance_bundles.go
@@ -304,60 +304,70 @@ func (c *ApiService) PageBundle(params *ListBundleParams, pageToken, pageNumber 
 
 // Lists Bundle records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListBundle(params *ListBundleParams) ([]NumbersV2Bundle, error) {
-	response, err := c.StreamBundle(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamBundle(params)
 
 	records := make([]NumbersV2Bundle, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Bundle records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamBundle(params *ListBundleParams) (chan NumbersV2Bundle, error) {
+func (c *ApiService) StreamBundle(params *ListBundleParams) (chan NumbersV2Bundle, chan error) {
 	if params == nil {
 		params = &ListBundleParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan NumbersV2Bundle, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageBundle(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamBundle(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamBundle(response *ListBundleResponse, params *ListBundleParams, recordChannel chan NumbersV2Bundle, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan NumbersV2Bundle, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Results
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListBundleResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Results
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListBundleResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListBundleResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListBundleResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListBundleResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/numbers/v2/regulatory_compliance_bundles_copies.go
+++ b/rest/numbers/v2/regulatory_compliance_bundles_copies.go
@@ -112,60 +112,70 @@ func (c *ApiService) PageBundleCopy(BundleSid string, params *ListBundleCopyPara
 
 // Lists BundleCopy records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListBundleCopy(BundleSid string, params *ListBundleCopyParams) ([]NumbersV2BundleCopy, error) {
-	response, err := c.StreamBundleCopy(BundleSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamBundleCopy(BundleSid, params)
 
 	records := make([]NumbersV2BundleCopy, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams BundleCopy records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamBundleCopy(BundleSid string, params *ListBundleCopyParams) (chan NumbersV2BundleCopy, error) {
+func (c *ApiService) StreamBundleCopy(BundleSid string, params *ListBundleCopyParams) (chan NumbersV2BundleCopy, chan error) {
 	if params == nil {
 		params = &ListBundleCopyParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan NumbersV2BundleCopy, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageBundleCopy(BundleSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamBundleCopy(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamBundleCopy(response *ListBundleCopyResponse, params *ListBundleCopyParams, recordChannel chan NumbersV2BundleCopy, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan NumbersV2BundleCopy, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Results
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListBundleCopyResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Results
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListBundleCopyResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListBundleCopyResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListBundleCopyResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListBundleCopyResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/numbers/v2/regulatory_compliance_bundles_evaluations.go
+++ b/rest/numbers/v2/regulatory_compliance_bundles_evaluations.go
@@ -121,60 +121,70 @@ func (c *ApiService) PageEvaluation(BundleSid string, params *ListEvaluationPara
 
 // Lists Evaluation records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListEvaluation(BundleSid string, params *ListEvaluationParams) ([]NumbersV2Evaluation, error) {
-	response, err := c.StreamEvaluation(BundleSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamEvaluation(BundleSid, params)
 
 	records := make([]NumbersV2Evaluation, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Evaluation records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamEvaluation(BundleSid string, params *ListEvaluationParams) (chan NumbersV2Evaluation, error) {
+func (c *ApiService) StreamEvaluation(BundleSid string, params *ListEvaluationParams) (chan NumbersV2Evaluation, chan error) {
 	if params == nil {
 		params = &ListEvaluationParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan NumbersV2Evaluation, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageEvaluation(BundleSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamEvaluation(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamEvaluation(response *ListEvaluationResponse, params *ListEvaluationParams, recordChannel chan NumbersV2Evaluation, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan NumbersV2Evaluation, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Results
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListEvaluationResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Results
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListEvaluationResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListEvaluationResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListEvaluationResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListEvaluationResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/numbers/v2/regulatory_compliance_bundles_item_assignments.go
+++ b/rest/numbers/v2/regulatory_compliance_bundles_item_assignments.go
@@ -155,60 +155,70 @@ func (c *ApiService) PageItemAssignment(BundleSid string, params *ListItemAssign
 
 // Lists ItemAssignment records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListItemAssignment(BundleSid string, params *ListItemAssignmentParams) ([]NumbersV2ItemAssignment, error) {
-	response, err := c.StreamItemAssignment(BundleSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamItemAssignment(BundleSid, params)
 
 	records := make([]NumbersV2ItemAssignment, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ItemAssignment records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamItemAssignment(BundleSid string, params *ListItemAssignmentParams) (chan NumbersV2ItemAssignment, error) {
+func (c *ApiService) StreamItemAssignment(BundleSid string, params *ListItemAssignmentParams) (chan NumbersV2ItemAssignment, chan error) {
 	if params == nil {
 		params = &ListItemAssignmentParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan NumbersV2ItemAssignment, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageItemAssignment(BundleSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamItemAssignment(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamItemAssignment(response *ListItemAssignmentResponse, params *ListItemAssignmentParams, recordChannel chan NumbersV2ItemAssignment, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan NumbersV2ItemAssignment, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Results
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListItemAssignmentResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Results
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListItemAssignmentResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListItemAssignmentResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListItemAssignmentResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListItemAssignmentResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/numbers/v2/regulatory_compliance_end_user_types.go
+++ b/rest/numbers/v2/regulatory_compliance_end_user_types.go
@@ -95,60 +95,70 @@ func (c *ApiService) PageEndUserType(params *ListEndUserTypeParams, pageToken, p
 
 // Lists EndUserType records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListEndUserType(params *ListEndUserTypeParams) ([]NumbersV2EndUserType, error) {
-	response, err := c.StreamEndUserType(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamEndUserType(params)
 
 	records := make([]NumbersV2EndUserType, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams EndUserType records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamEndUserType(params *ListEndUserTypeParams) (chan NumbersV2EndUserType, error) {
+func (c *ApiService) StreamEndUserType(params *ListEndUserTypeParams) (chan NumbersV2EndUserType, chan error) {
 	if params == nil {
 		params = &ListEndUserTypeParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan NumbersV2EndUserType, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageEndUserType(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamEndUserType(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamEndUserType(response *ListEndUserTypeResponse, params *ListEndUserTypeParams, recordChannel chan NumbersV2EndUserType, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan NumbersV2EndUserType, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.EndUserTypes
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListEndUserTypeResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.EndUserTypes
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListEndUserTypeResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListEndUserTypeResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListEndUserTypeResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListEndUserTypeResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/numbers/v2/regulatory_compliance_end_users.go
+++ b/rest/numbers/v2/regulatory_compliance_end_users.go
@@ -174,60 +174,70 @@ func (c *ApiService) PageEndUser(params *ListEndUserParams, pageToken, pageNumbe
 
 // Lists EndUser records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListEndUser(params *ListEndUserParams) ([]NumbersV2EndUser, error) {
-	response, err := c.StreamEndUser(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamEndUser(params)
 
 	records := make([]NumbersV2EndUser, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams EndUser records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamEndUser(params *ListEndUserParams) (chan NumbersV2EndUser, error) {
+func (c *ApiService) StreamEndUser(params *ListEndUserParams) (chan NumbersV2EndUser, chan error) {
 	if params == nil {
 		params = &ListEndUserParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan NumbersV2EndUser, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageEndUser(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamEndUser(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamEndUser(response *ListEndUserResponse, params *ListEndUserParams, recordChannel chan NumbersV2EndUser, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan NumbersV2EndUser, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Results
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListEndUserResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Results
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListEndUserResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListEndUserResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListEndUserResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListEndUserResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/numbers/v2/regulatory_compliance_regulations.go
+++ b/rest/numbers/v2/regulatory_compliance_regulations.go
@@ -122,60 +122,70 @@ func (c *ApiService) PageRegulation(params *ListRegulationParams, pageToken, pag
 
 // Lists Regulation records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRegulation(params *ListRegulationParams) ([]NumbersV2Regulation, error) {
-	response, err := c.StreamRegulation(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamRegulation(params)
 
 	records := make([]NumbersV2Regulation, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Regulation records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamRegulation(params *ListRegulationParams) (chan NumbersV2Regulation, error) {
+func (c *ApiService) StreamRegulation(params *ListRegulationParams) (chan NumbersV2Regulation, chan error) {
 	if params == nil {
 		params = &ListRegulationParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan NumbersV2Regulation, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageRegulation(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamRegulation(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamRegulation(response *ListRegulationResponse, params *ListRegulationParams, recordChannel chan NumbersV2Regulation, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan NumbersV2Regulation, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Results
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListRegulationResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Results
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListRegulationResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListRegulationResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListRegulationResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListRegulationResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/numbers/v2/regulatory_compliance_supporting_document_types.go
+++ b/rest/numbers/v2/regulatory_compliance_supporting_document_types.go
@@ -95,60 +95,70 @@ func (c *ApiService) PageSupportingDocumentType(params *ListSupportingDocumentTy
 
 // Lists SupportingDocumentType records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSupportingDocumentType(params *ListSupportingDocumentTypeParams) ([]NumbersV2SupportingDocumentType, error) {
-	response, err := c.StreamSupportingDocumentType(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamSupportingDocumentType(params)
 
 	records := make([]NumbersV2SupportingDocumentType, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams SupportingDocumentType records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamSupportingDocumentType(params *ListSupportingDocumentTypeParams) (chan NumbersV2SupportingDocumentType, error) {
+func (c *ApiService) StreamSupportingDocumentType(params *ListSupportingDocumentTypeParams) (chan NumbersV2SupportingDocumentType, chan error) {
 	if params == nil {
 		params = &ListSupportingDocumentTypeParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan NumbersV2SupportingDocumentType, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageSupportingDocumentType(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamSupportingDocumentType(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamSupportingDocumentType(response *ListSupportingDocumentTypeResponse, params *ListSupportingDocumentTypeParams, recordChannel chan NumbersV2SupportingDocumentType, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan NumbersV2SupportingDocumentType, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.SupportingDocumentTypes
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListSupportingDocumentTypeResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.SupportingDocumentTypes
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListSupportingDocumentTypeResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListSupportingDocumentTypeResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListSupportingDocumentTypeResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListSupportingDocumentTypeResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/numbers/v2/regulatory_compliance_supporting_documents.go
+++ b/rest/numbers/v2/regulatory_compliance_supporting_documents.go
@@ -174,60 +174,70 @@ func (c *ApiService) PageSupportingDocument(params *ListSupportingDocumentParams
 
 // Lists SupportingDocument records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSupportingDocument(params *ListSupportingDocumentParams) ([]NumbersV2SupportingDocument, error) {
-	response, err := c.StreamSupportingDocument(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamSupportingDocument(params)
 
 	records := make([]NumbersV2SupportingDocument, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams SupportingDocument records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamSupportingDocument(params *ListSupportingDocumentParams) (chan NumbersV2SupportingDocument, error) {
+func (c *ApiService) StreamSupportingDocument(params *ListSupportingDocumentParams) (chan NumbersV2SupportingDocument, chan error) {
 	if params == nil {
 		params = &ListSupportingDocumentParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan NumbersV2SupportingDocument, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageSupportingDocument(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamSupportingDocument(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamSupportingDocument(response *ListSupportingDocumentResponse, params *ListSupportingDocumentParams, recordChannel chan NumbersV2SupportingDocument, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan NumbersV2SupportingDocument, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Results
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListSupportingDocumentResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Results
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListSupportingDocumentResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListSupportingDocumentResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListSupportingDocumentResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListSupportingDocumentResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/pricing/v1/messaging_countries.go
+++ b/rest/pricing/v1/messaging_countries.go
@@ -94,60 +94,70 @@ func (c *ApiService) PageMessagingCountry(params *ListMessagingCountryParams, pa
 
 // Lists MessagingCountry records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListMessagingCountry(params *ListMessagingCountryParams) ([]PricingV1MessagingCountry, error) {
-	response, err := c.StreamMessagingCountry(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamMessagingCountry(params)
 
 	records := make([]PricingV1MessagingCountry, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams MessagingCountry records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamMessagingCountry(params *ListMessagingCountryParams) (chan PricingV1MessagingCountry, error) {
+func (c *ApiService) StreamMessagingCountry(params *ListMessagingCountryParams) (chan PricingV1MessagingCountry, chan error) {
 	if params == nil {
 		params = &ListMessagingCountryParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan PricingV1MessagingCountry, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageMessagingCountry(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamMessagingCountry(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamMessagingCountry(response *ListMessagingCountryResponse, params *ListMessagingCountryParams, recordChannel chan PricingV1MessagingCountry, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan PricingV1MessagingCountry, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Countries
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListMessagingCountryResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Countries
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListMessagingCountryResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListMessagingCountryResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListMessagingCountryResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListMessagingCountryResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/pricing/v1/voice_countries.go
+++ b/rest/pricing/v1/voice_countries.go
@@ -94,60 +94,70 @@ func (c *ApiService) PageVoiceCountry(params *ListVoiceCountryParams, pageToken,
 
 // Lists VoiceCountry records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListVoiceCountry(params *ListVoiceCountryParams) ([]PricingV1VoiceCountry, error) {
-	response, err := c.StreamVoiceCountry(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamVoiceCountry(params)
 
 	records := make([]PricingV1VoiceCountry, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams VoiceCountry records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamVoiceCountry(params *ListVoiceCountryParams) (chan PricingV1VoiceCountry, error) {
+func (c *ApiService) StreamVoiceCountry(params *ListVoiceCountryParams) (chan PricingV1VoiceCountry, chan error) {
 	if params == nil {
 		params = &ListVoiceCountryParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan PricingV1VoiceCountry, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageVoiceCountry(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamVoiceCountry(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamVoiceCountry(response *ListVoiceCountryResponse, params *ListVoiceCountryParams, recordChannel chan PricingV1VoiceCountry, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan PricingV1VoiceCountry, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Countries
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListVoiceCountryResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Countries
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListVoiceCountryResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListVoiceCountryResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListVoiceCountryResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListVoiceCountryResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/pricing/v2/trunking_countries.go
+++ b/rest/pricing/v2/trunking_countries.go
@@ -95,60 +95,70 @@ func (c *ApiService) PageTrunkingCountry(params *ListTrunkingCountryParams, page
 
 // Lists TrunkingCountry records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListTrunkingCountry(params *ListTrunkingCountryParams) ([]PricingV2TrunkingCountry, error) {
-	response, err := c.StreamTrunkingCountry(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamTrunkingCountry(params)
 
 	records := make([]PricingV2TrunkingCountry, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams TrunkingCountry records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamTrunkingCountry(params *ListTrunkingCountryParams) (chan PricingV2TrunkingCountry, error) {
+func (c *ApiService) StreamTrunkingCountry(params *ListTrunkingCountryParams) (chan PricingV2TrunkingCountry, chan error) {
 	if params == nil {
 		params = &ListTrunkingCountryParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan PricingV2TrunkingCountry, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageTrunkingCountry(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamTrunkingCountry(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamTrunkingCountry(response *ListTrunkingCountryResponse, params *ListTrunkingCountryParams, recordChannel chan PricingV2TrunkingCountry, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan PricingV2TrunkingCountry, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Countries
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListTrunkingCountryResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Countries
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListTrunkingCountryResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListTrunkingCountryResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListTrunkingCountryResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListTrunkingCountryResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/pricing/v2/voice_countries.go
+++ b/rest/pricing/v2/voice_countries.go
@@ -95,60 +95,70 @@ func (c *ApiService) PageVoiceCountry(params *ListVoiceCountryParams, pageToken,
 
 // Lists VoiceCountry records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListVoiceCountry(params *ListVoiceCountryParams) ([]PricingV2VoiceCountry, error) {
-	response, err := c.StreamVoiceCountry(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamVoiceCountry(params)
 
 	records := make([]PricingV2VoiceCountry, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams VoiceCountry records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamVoiceCountry(params *ListVoiceCountryParams) (chan PricingV2VoiceCountry, error) {
+func (c *ApiService) StreamVoiceCountry(params *ListVoiceCountryParams) (chan PricingV2VoiceCountry, chan error) {
 	if params == nil {
 		params = &ListVoiceCountryParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan PricingV2VoiceCountry, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageVoiceCountry(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamVoiceCountry(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamVoiceCountry(response *ListVoiceCountryResponse, params *ListVoiceCountryParams, recordChannel chan PricingV2VoiceCountry, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan PricingV2VoiceCountry, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Countries
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListVoiceCountryResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Countries
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListVoiceCountryResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListVoiceCountryResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListVoiceCountryResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListVoiceCountryResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/proxy/v1/services.go
+++ b/rest/proxy/v1/services.go
@@ -213,60 +213,70 @@ func (c *ApiService) PageService(params *ListServiceParams, pageToken, pageNumbe
 
 // Lists Service records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListService(params *ListServiceParams) ([]ProxyV1Service, error) {
-	response, err := c.StreamService(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamService(params)
 
 	records := make([]ProxyV1Service, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Service records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamService(params *ListServiceParams) (chan ProxyV1Service, error) {
+func (c *ApiService) StreamService(params *ListServiceParams) (chan ProxyV1Service, chan error) {
 	if params == nil {
 		params = &ListServiceParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ProxyV1Service, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageService(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamService(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamService(response *ListServiceResponse, params *ListServiceParams, recordChannel chan ProxyV1Service, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ProxyV1Service, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Services
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Services
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListServiceResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListServiceResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListServiceResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListServiceResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/proxy/v1/services_phone_numbers.go
+++ b/rest/proxy/v1/services_phone_numbers.go
@@ -173,60 +173,70 @@ func (c *ApiService) PagePhoneNumber(ServiceSid string, params *ListPhoneNumberP
 
 // Lists PhoneNumber records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListPhoneNumber(ServiceSid string, params *ListPhoneNumberParams) ([]ProxyV1PhoneNumber, error) {
-	response, err := c.StreamPhoneNumber(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamPhoneNumber(ServiceSid, params)
 
 	records := make([]ProxyV1PhoneNumber, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams PhoneNumber records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamPhoneNumber(ServiceSid string, params *ListPhoneNumberParams) (chan ProxyV1PhoneNumber, error) {
+func (c *ApiService) StreamPhoneNumber(ServiceSid string, params *ListPhoneNumberParams) (chan ProxyV1PhoneNumber, chan error) {
 	if params == nil {
 		params = &ListPhoneNumberParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ProxyV1PhoneNumber, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PagePhoneNumber(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamPhoneNumber(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamPhoneNumber(response *ListPhoneNumberResponse, params *ListPhoneNumberParams, recordChannel chan ProxyV1PhoneNumber, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ProxyV1PhoneNumber, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.PhoneNumbers
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListPhoneNumberResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.PhoneNumbers
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListPhoneNumberResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListPhoneNumberResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListPhoneNumberResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListPhoneNumberResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/proxy/v1/services_sessions_interactions.go
+++ b/rest/proxy/v1/services_sessions_interactions.go
@@ -120,60 +120,70 @@ func (c *ApiService) PageInteraction(ServiceSid string, SessionSid string, param
 
 // Lists Interaction records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListInteraction(ServiceSid string, SessionSid string, params *ListInteractionParams) ([]ProxyV1Interaction, error) {
-	response, err := c.StreamInteraction(ServiceSid, SessionSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamInteraction(ServiceSid, SessionSid, params)
 
 	records := make([]ProxyV1Interaction, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Interaction records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamInteraction(ServiceSid string, SessionSid string, params *ListInteractionParams) (chan ProxyV1Interaction, error) {
+func (c *ApiService) StreamInteraction(ServiceSid string, SessionSid string, params *ListInteractionParams) (chan ProxyV1Interaction, chan error) {
 	if params == nil {
 		params = &ListInteractionParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ProxyV1Interaction, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageInteraction(ServiceSid, SessionSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamInteraction(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamInteraction(response *ListInteractionResponse, params *ListInteractionParams, recordChannel chan ProxyV1Interaction, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ProxyV1Interaction, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Interactions
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListInteractionResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Interactions
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListInteractionResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListInteractionResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListInteractionResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListInteractionResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/proxy/v1/services_sessions_participants.go
+++ b/rest/proxy/v1/services_sessions_participants.go
@@ -195,60 +195,70 @@ func (c *ApiService) PageParticipant(ServiceSid string, SessionSid string, param
 
 // Lists Participant records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListParticipant(ServiceSid string, SessionSid string, params *ListParticipantParams) ([]ProxyV1Participant, error) {
-	response, err := c.StreamParticipant(ServiceSid, SessionSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamParticipant(ServiceSid, SessionSid, params)
 
 	records := make([]ProxyV1Participant, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Participant records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamParticipant(ServiceSid string, SessionSid string, params *ListParticipantParams) (chan ProxyV1Participant, error) {
+func (c *ApiService) StreamParticipant(ServiceSid string, SessionSid string, params *ListParticipantParams) (chan ProxyV1Participant, chan error) {
 	if params == nil {
 		params = &ListParticipantParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ProxyV1Participant, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageParticipant(ServiceSid, SessionSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamParticipant(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamParticipant(response *ListParticipantResponse, params *ListParticipantParams, recordChannel chan ProxyV1Participant, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ProxyV1Participant, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Participants
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListParticipantResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Participants
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListParticipantResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListParticipantResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListParticipantResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListParticipantResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/proxy/v1/services_short_codes.go
+++ b/rest/proxy/v1/services_short_codes.go
@@ -155,60 +155,70 @@ func (c *ApiService) PageShortCode(ServiceSid string, params *ListShortCodeParam
 
 // Lists ShortCode records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListShortCode(ServiceSid string, params *ListShortCodeParams) ([]ProxyV1ShortCode, error) {
-	response, err := c.StreamShortCode(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamShortCode(ServiceSid, params)
 
 	records := make([]ProxyV1ShortCode, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ShortCode records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamShortCode(ServiceSid string, params *ListShortCodeParams) (chan ProxyV1ShortCode, error) {
+func (c *ApiService) StreamShortCode(ServiceSid string, params *ListShortCodeParams) (chan ProxyV1ShortCode, chan error) {
 	if params == nil {
 		params = &ListShortCodeParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ProxyV1ShortCode, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageShortCode(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamShortCode(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamShortCode(response *ListShortCodeResponse, params *ListShortCodeParams, recordChannel chan ProxyV1ShortCode, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ProxyV1ShortCode, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.ShortCodes
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListShortCodeResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.ShortCodes
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListShortCodeResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListShortCodeResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListShortCodeResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListShortCodeResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/serverless/v1/services.go
+++ b/rest/serverless/v1/services.go
@@ -177,60 +177,70 @@ func (c *ApiService) PageService(params *ListServiceParams, pageToken, pageNumbe
 
 // Lists Service records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListService(params *ListServiceParams) ([]ServerlessV1Service, error) {
-	response, err := c.StreamService(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamService(params)
 
 	records := make([]ServerlessV1Service, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Service records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamService(params *ListServiceParams) (chan ServerlessV1Service, error) {
+func (c *ApiService) StreamService(params *ListServiceParams) (chan ServerlessV1Service, chan error) {
 	if params == nil {
 		params = &ListServiceParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ServerlessV1Service, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageService(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamService(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamService(response *ListServiceResponse, params *ListServiceParams, recordChannel chan ServerlessV1Service, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ServerlessV1Service, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Services
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Services
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListServiceResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListServiceResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListServiceResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListServiceResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/serverless/v1/services_assets.go
+++ b/rest/serverless/v1/services_assets.go
@@ -155,60 +155,70 @@ func (c *ApiService) PageAsset(ServiceSid string, params *ListAssetParams, pageT
 
 // Lists Asset records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListAsset(ServiceSid string, params *ListAssetParams) ([]ServerlessV1Asset, error) {
-	response, err := c.StreamAsset(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamAsset(ServiceSid, params)
 
 	records := make([]ServerlessV1Asset, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Asset records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamAsset(ServiceSid string, params *ListAssetParams) (chan ServerlessV1Asset, error) {
+func (c *ApiService) StreamAsset(ServiceSid string, params *ListAssetParams) (chan ServerlessV1Asset, chan error) {
 	if params == nil {
 		params = &ListAssetParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ServerlessV1Asset, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageAsset(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamAsset(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamAsset(response *ListAssetResponse, params *ListAssetParams, recordChannel chan ServerlessV1Asset, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ServerlessV1Asset, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Assets
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListAssetResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Assets
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListAssetResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListAssetResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListAssetResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListAssetResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/serverless/v1/services_builds.go
+++ b/rest/serverless/v1/services_builds.go
@@ -186,60 +186,70 @@ func (c *ApiService) PageBuild(ServiceSid string, params *ListBuildParams, pageT
 
 // Lists Build records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListBuild(ServiceSid string, params *ListBuildParams) ([]ServerlessV1Build, error) {
-	response, err := c.StreamBuild(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamBuild(ServiceSid, params)
 
 	records := make([]ServerlessV1Build, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Build records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamBuild(ServiceSid string, params *ListBuildParams) (chan ServerlessV1Build, error) {
+func (c *ApiService) StreamBuild(ServiceSid string, params *ListBuildParams) (chan ServerlessV1Build, chan error) {
 	if params == nil {
 		params = &ListBuildParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ServerlessV1Build, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageBuild(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamBuild(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamBuild(response *ListBuildResponse, params *ListBuildParams, recordChannel chan ServerlessV1Build, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ServerlessV1Build, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Builds
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListBuildResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Builds
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListBuildResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListBuildResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListBuildResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListBuildResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/serverless/v1/services_environments.go
+++ b/rest/serverless/v1/services_environments.go
@@ -164,60 +164,70 @@ func (c *ApiService) PageEnvironment(ServiceSid string, params *ListEnvironmentP
 
 // Lists Environment records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListEnvironment(ServiceSid string, params *ListEnvironmentParams) ([]ServerlessV1Environment, error) {
-	response, err := c.StreamEnvironment(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamEnvironment(ServiceSid, params)
 
 	records := make([]ServerlessV1Environment, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Environment records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamEnvironment(ServiceSid string, params *ListEnvironmentParams) (chan ServerlessV1Environment, error) {
+func (c *ApiService) StreamEnvironment(ServiceSid string, params *ListEnvironmentParams) (chan ServerlessV1Environment, chan error) {
 	if params == nil {
 		params = &ListEnvironmentParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ServerlessV1Environment, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageEnvironment(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamEnvironment(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamEnvironment(response *ListEnvironmentResponse, params *ListEnvironmentParams, recordChannel chan ServerlessV1Environment, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ServerlessV1Environment, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Environments
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListEnvironmentResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Environments
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListEnvironmentResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListEnvironmentResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListEnvironmentResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListEnvironmentResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/serverless/v1/services_environments_deployments.go
+++ b/rest/serverless/v1/services_environments_deployments.go
@@ -139,60 +139,70 @@ func (c *ApiService) PageDeployment(ServiceSid string, EnvironmentSid string, pa
 
 // Lists Deployment records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListDeployment(ServiceSid string, EnvironmentSid string, params *ListDeploymentParams) ([]ServerlessV1Deployment, error) {
-	response, err := c.StreamDeployment(ServiceSid, EnvironmentSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamDeployment(ServiceSid, EnvironmentSid, params)
 
 	records := make([]ServerlessV1Deployment, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Deployment records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamDeployment(ServiceSid string, EnvironmentSid string, params *ListDeploymentParams) (chan ServerlessV1Deployment, error) {
+func (c *ApiService) StreamDeployment(ServiceSid string, EnvironmentSid string, params *ListDeploymentParams) (chan ServerlessV1Deployment, chan error) {
 	if params == nil {
 		params = &ListDeploymentParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ServerlessV1Deployment, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageDeployment(ServiceSid, EnvironmentSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamDeployment(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamDeployment(response *ListDeploymentResponse, params *ListDeploymentParams, recordChannel chan ServerlessV1Deployment, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ServerlessV1Deployment, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Deployments
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListDeploymentResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Deployments
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListDeploymentResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListDeploymentResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListDeploymentResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListDeploymentResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/serverless/v1/services_environments_logs.go
+++ b/rest/serverless/v1/services_environments_logs.go
@@ -128,60 +128,70 @@ func (c *ApiService) PageLog(ServiceSid string, EnvironmentSid string, params *L
 
 // Lists Log records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListLog(ServiceSid string, EnvironmentSid string, params *ListLogParams) ([]ServerlessV1Log, error) {
-	response, err := c.StreamLog(ServiceSid, EnvironmentSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamLog(ServiceSid, EnvironmentSid, params)
 
 	records := make([]ServerlessV1Log, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Log records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamLog(ServiceSid string, EnvironmentSid string, params *ListLogParams) (chan ServerlessV1Log, error) {
+func (c *ApiService) StreamLog(ServiceSid string, EnvironmentSid string, params *ListLogParams) (chan ServerlessV1Log, chan error) {
 	if params == nil {
 		params = &ListLogParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ServerlessV1Log, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageLog(ServiceSid, EnvironmentSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamLog(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamLog(response *ListLogResponse, params *ListLogParams, recordChannel chan ServerlessV1Log, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ServerlessV1Log, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Logs
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListLogResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Logs
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListLogResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListLogResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListLogResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListLogResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/serverless/v1/services_environments_variables.go
+++ b/rest/serverless/v1/services_environments_variables.go
@@ -168,60 +168,70 @@ func (c *ApiService) PageVariable(ServiceSid string, EnvironmentSid string, para
 
 // Lists Variable records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListVariable(ServiceSid string, EnvironmentSid string, params *ListVariableParams) ([]ServerlessV1Variable, error) {
-	response, err := c.StreamVariable(ServiceSid, EnvironmentSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamVariable(ServiceSid, EnvironmentSid, params)
 
 	records := make([]ServerlessV1Variable, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Variable records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamVariable(ServiceSid string, EnvironmentSid string, params *ListVariableParams) (chan ServerlessV1Variable, error) {
+func (c *ApiService) StreamVariable(ServiceSid string, EnvironmentSid string, params *ListVariableParams) (chan ServerlessV1Variable, chan error) {
 	if params == nil {
 		params = &ListVariableParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ServerlessV1Variable, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageVariable(ServiceSid, EnvironmentSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamVariable(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamVariable(response *ListVariableResponse, params *ListVariableParams, recordChannel chan ServerlessV1Variable, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ServerlessV1Variable, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Variables
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListVariableResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Variables
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListVariableResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListVariableResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListVariableResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListVariableResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/serverless/v1/services_functions.go
+++ b/rest/serverless/v1/services_functions.go
@@ -155,60 +155,70 @@ func (c *ApiService) PageFunction(ServiceSid string, params *ListFunctionParams,
 
 // Lists Function records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListFunction(ServiceSid string, params *ListFunctionParams) ([]ServerlessV1Function, error) {
-	response, err := c.StreamFunction(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamFunction(ServiceSid, params)
 
 	records := make([]ServerlessV1Function, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Function records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamFunction(ServiceSid string, params *ListFunctionParams) (chan ServerlessV1Function, error) {
+func (c *ApiService) StreamFunction(ServiceSid string, params *ListFunctionParams) (chan ServerlessV1Function, chan error) {
 	if params == nil {
 		params = &ListFunctionParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ServerlessV1Function, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageFunction(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamFunction(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamFunction(response *ListFunctionResponse, params *ListFunctionParams, recordChannel chan ServerlessV1Function, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ServerlessV1Function, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Functions
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListFunctionResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Functions
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListFunctionResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListFunctionResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListFunctionResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListFunctionResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/serverless/v1/services_functions_versions.go
+++ b/rest/serverless/v1/services_functions_versions.go
@@ -100,60 +100,70 @@ func (c *ApiService) PageFunctionVersion(ServiceSid string, FunctionSid string, 
 
 // Lists FunctionVersion records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListFunctionVersion(ServiceSid string, FunctionSid string, params *ListFunctionVersionParams) ([]ServerlessV1FunctionVersion, error) {
-	response, err := c.StreamFunctionVersion(ServiceSid, FunctionSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamFunctionVersion(ServiceSid, FunctionSid, params)
 
 	records := make([]ServerlessV1FunctionVersion, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams FunctionVersion records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamFunctionVersion(ServiceSid string, FunctionSid string, params *ListFunctionVersionParams) (chan ServerlessV1FunctionVersion, error) {
+func (c *ApiService) StreamFunctionVersion(ServiceSid string, FunctionSid string, params *ListFunctionVersionParams) (chan ServerlessV1FunctionVersion, chan error) {
 	if params == nil {
 		params = &ListFunctionVersionParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan ServerlessV1FunctionVersion, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageFunctionVersion(ServiceSid, FunctionSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamFunctionVersion(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamFunctionVersion(response *ListFunctionVersionResponse, params *ListFunctionVersionParams, recordChannel chan ServerlessV1FunctionVersion, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan ServerlessV1FunctionVersion, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.FunctionVersions
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListFunctionVersionResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.FunctionVersions
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListFunctionVersionResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListFunctionVersionResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListFunctionVersionResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListFunctionVersionResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/studio/v1/flows.go
+++ b/rest/studio/v1/flows.go
@@ -113,60 +113,70 @@ func (c *ApiService) PageFlow(params *ListFlowParams, pageToken, pageNumber stri
 
 // Lists Flow records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListFlow(params *ListFlowParams) ([]StudioV1Flow, error) {
-	response, err := c.StreamFlow(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamFlow(params)
 
 	records := make([]StudioV1Flow, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Flow records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamFlow(params *ListFlowParams) (chan StudioV1Flow, error) {
+func (c *ApiService) StreamFlow(params *ListFlowParams) (chan StudioV1Flow, chan error) {
 	if params == nil {
 		params = &ListFlowParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan StudioV1Flow, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageFlow(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamFlow(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamFlow(response *ListFlowResponse, params *ListFlowParams, recordChannel chan StudioV1Flow, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan StudioV1Flow, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Flows
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListFlowResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Flows
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListFlowResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListFlowResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListFlowResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListFlowResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/studio/v1/flows_engagements_steps.go
+++ b/rest/studio/v1/flows_engagements_steps.go
@@ -100,60 +100,70 @@ func (c *ApiService) PageStep(FlowSid string, EngagementSid string, params *List
 
 // Lists Step records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListStep(FlowSid string, EngagementSid string, params *ListStepParams) ([]StudioV1Step, error) {
-	response, err := c.StreamStep(FlowSid, EngagementSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamStep(FlowSid, EngagementSid, params)
 
 	records := make([]StudioV1Step, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Step records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamStep(FlowSid string, EngagementSid string, params *ListStepParams) (chan StudioV1Step, error) {
+func (c *ApiService) StreamStep(FlowSid string, EngagementSid string, params *ListStepParams) (chan StudioV1Step, chan error) {
 	if params == nil {
 		params = &ListStepParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan StudioV1Step, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageStep(FlowSid, EngagementSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamStep(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamStep(response *ListStepResponse, params *ListStepParams, recordChannel chan StudioV1Step, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan StudioV1Step, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Steps
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListStepResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Steps
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListStepResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListStepResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListStepResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListStepResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/studio/v1/flows_executions.go
+++ b/rest/studio/v1/flows_executions.go
@@ -198,60 +198,70 @@ func (c *ApiService) PageExecution(FlowSid string, params *ListExecutionParams, 
 
 // Lists Execution records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListExecution(FlowSid string, params *ListExecutionParams) ([]StudioV1Execution, error) {
-	response, err := c.StreamExecution(FlowSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamExecution(FlowSid, params)
 
 	records := make([]StudioV1Execution, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Execution records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamExecution(FlowSid string, params *ListExecutionParams) (chan StudioV1Execution, error) {
+func (c *ApiService) StreamExecution(FlowSid string, params *ListExecutionParams) (chan StudioV1Execution, chan error) {
 	if params == nil {
 		params = &ListExecutionParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan StudioV1Execution, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageExecution(FlowSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamExecution(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamExecution(response *ListExecutionResponse, params *ListExecutionParams, recordChannel chan StudioV1Execution, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan StudioV1Execution, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Executions
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListExecutionResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Executions
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListExecutionResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListExecutionResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListExecutionResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListExecutionResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/studio/v1/flows_executions_steps.go
+++ b/rest/studio/v1/flows_executions_steps.go
@@ -100,60 +100,70 @@ func (c *ApiService) PageExecutionStep(FlowSid string, ExecutionSid string, para
 
 // Lists ExecutionStep records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListExecutionStep(FlowSid string, ExecutionSid string, params *ListExecutionStepParams) ([]StudioV1ExecutionStep, error) {
-	response, err := c.StreamExecutionStep(FlowSid, ExecutionSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamExecutionStep(FlowSid, ExecutionSid, params)
 
 	records := make([]StudioV1ExecutionStep, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ExecutionStep records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamExecutionStep(FlowSid string, ExecutionSid string, params *ListExecutionStepParams) (chan StudioV1ExecutionStep, error) {
+func (c *ApiService) StreamExecutionStep(FlowSid string, ExecutionSid string, params *ListExecutionStepParams) (chan StudioV1ExecutionStep, chan error) {
 	if params == nil {
 		params = &ListExecutionStepParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan StudioV1ExecutionStep, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageExecutionStep(FlowSid, ExecutionSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamExecutionStep(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamExecutionStep(response *ListExecutionStepResponse, params *ListExecutionStepParams, recordChannel chan StudioV1ExecutionStep, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan StudioV1ExecutionStep, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Steps
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListExecutionStepResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Steps
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListExecutionStepResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListExecutionStepResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListExecutionStepResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListExecutionStepResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/studio/v2/flows.go
+++ b/rest/studio/v2/flows.go
@@ -183,60 +183,70 @@ func (c *ApiService) PageFlow(params *ListFlowParams, pageToken, pageNumber stri
 
 // Lists Flow records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListFlow(params *ListFlowParams) ([]StudioV2Flow, error) {
-	response, err := c.StreamFlow(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamFlow(params)
 
 	records := make([]StudioV2Flow, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Flow records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamFlow(params *ListFlowParams) (chan StudioV2Flow, error) {
+func (c *ApiService) StreamFlow(params *ListFlowParams) (chan StudioV2Flow, chan error) {
 	if params == nil {
 		params = &ListFlowParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan StudioV2Flow, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageFlow(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamFlow(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamFlow(response *ListFlowResponse, params *ListFlowParams, recordChannel chan StudioV2Flow, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan StudioV2Flow, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Flows
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListFlowResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Flows
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListFlowResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListFlowResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListFlowResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListFlowResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/studio/v2/flows_executions.go
+++ b/rest/studio/v2/flows_executions.go
@@ -198,60 +198,70 @@ func (c *ApiService) PageExecution(FlowSid string, params *ListExecutionParams, 
 
 // Lists Execution records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListExecution(FlowSid string, params *ListExecutionParams) ([]StudioV2Execution, error) {
-	response, err := c.StreamExecution(FlowSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamExecution(FlowSid, params)
 
 	records := make([]StudioV2Execution, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Execution records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamExecution(FlowSid string, params *ListExecutionParams) (chan StudioV2Execution, error) {
+func (c *ApiService) StreamExecution(FlowSid string, params *ListExecutionParams) (chan StudioV2Execution, chan error) {
 	if params == nil {
 		params = &ListExecutionParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan StudioV2Execution, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageExecution(FlowSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamExecution(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamExecution(response *ListExecutionResponse, params *ListExecutionParams, recordChannel chan StudioV2Execution, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan StudioV2Execution, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Executions
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListExecutionResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Executions
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListExecutionResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListExecutionResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListExecutionResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListExecutionResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/studio/v2/flows_executions_steps.go
+++ b/rest/studio/v2/flows_executions_steps.go
@@ -100,60 +100,70 @@ func (c *ApiService) PageExecutionStep(FlowSid string, ExecutionSid string, para
 
 // Lists ExecutionStep records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListExecutionStep(FlowSid string, ExecutionSid string, params *ListExecutionStepParams) ([]StudioV2ExecutionStep, error) {
-	response, err := c.StreamExecutionStep(FlowSid, ExecutionSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamExecutionStep(FlowSid, ExecutionSid, params)
 
 	records := make([]StudioV2ExecutionStep, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ExecutionStep records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamExecutionStep(FlowSid string, ExecutionSid string, params *ListExecutionStepParams) (chan StudioV2ExecutionStep, error) {
+func (c *ApiService) StreamExecutionStep(FlowSid string, ExecutionSid string, params *ListExecutionStepParams) (chan StudioV2ExecutionStep, chan error) {
 	if params == nil {
 		params = &ListExecutionStepParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan StudioV2ExecutionStep, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageExecutionStep(FlowSid, ExecutionSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamExecutionStep(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamExecutionStep(response *ListExecutionStepResponse, params *ListExecutionStepParams, recordChannel chan StudioV2ExecutionStep, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan StudioV2ExecutionStep, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Steps
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListExecutionStepResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Steps
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListExecutionStepResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListExecutionStepResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListExecutionStepResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListExecutionStepResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/supersim/v1/fleets.go
+++ b/rest/supersim/v1/fleets.go
@@ -213,60 +213,70 @@ func (c *ApiService) PageFleet(params *ListFleetParams, pageToken, pageNumber st
 
 // Lists Fleet records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListFleet(params *ListFleetParams) ([]SupersimV1Fleet, error) {
-	response, err := c.StreamFleet(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamFleet(params)
 
 	records := make([]SupersimV1Fleet, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Fleet records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamFleet(params *ListFleetParams) (chan SupersimV1Fleet, error) {
+func (c *ApiService) StreamFleet(params *ListFleetParams) (chan SupersimV1Fleet, chan error) {
 	if params == nil {
 		params = &ListFleetParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan SupersimV1Fleet, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageFleet(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamFleet(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamFleet(response *ListFleetResponse, params *ListFleetParams, recordChannel chan SupersimV1Fleet, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan SupersimV1Fleet, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Fleets
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListFleetResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Fleets
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListFleetResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListFleetResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListFleetResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListFleetResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/supersim/v1/ip_commands.go
+++ b/rest/supersim/v1/ip_commands.go
@@ -213,60 +213,70 @@ func (c *ApiService) PageIpCommand(params *ListIpCommandParams, pageToken, pageN
 
 // Lists IpCommand records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListIpCommand(params *ListIpCommandParams) ([]SupersimV1IpCommand, error) {
-	response, err := c.StreamIpCommand(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamIpCommand(params)
 
 	records := make([]SupersimV1IpCommand, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams IpCommand records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamIpCommand(params *ListIpCommandParams) (chan SupersimV1IpCommand, error) {
+func (c *ApiService) StreamIpCommand(params *ListIpCommandParams) (chan SupersimV1IpCommand, chan error) {
 	if params == nil {
 		params = &ListIpCommandParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan SupersimV1IpCommand, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageIpCommand(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamIpCommand(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamIpCommand(response *ListIpCommandResponse, params *ListIpCommandParams, recordChannel chan SupersimV1IpCommand, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan SupersimV1IpCommand, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.IpCommands
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListIpCommandResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.IpCommands
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListIpCommandResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListIpCommandResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListIpCommandResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListIpCommandResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/supersim/v1/network_access_profiles.go
+++ b/rest/supersim/v1/network_access_profiles.go
@@ -143,60 +143,70 @@ func (c *ApiService) PageNetworkAccessProfile(params *ListNetworkAccessProfilePa
 
 // Lists NetworkAccessProfile records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListNetworkAccessProfile(params *ListNetworkAccessProfileParams) ([]SupersimV1NetworkAccessProfile, error) {
-	response, err := c.StreamNetworkAccessProfile(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamNetworkAccessProfile(params)
 
 	records := make([]SupersimV1NetworkAccessProfile, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams NetworkAccessProfile records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamNetworkAccessProfile(params *ListNetworkAccessProfileParams) (chan SupersimV1NetworkAccessProfile, error) {
+func (c *ApiService) StreamNetworkAccessProfile(params *ListNetworkAccessProfileParams) (chan SupersimV1NetworkAccessProfile, chan error) {
 	if params == nil {
 		params = &ListNetworkAccessProfileParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan SupersimV1NetworkAccessProfile, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageNetworkAccessProfile(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamNetworkAccessProfile(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamNetworkAccessProfile(response *ListNetworkAccessProfileResponse, params *ListNetworkAccessProfileParams, recordChannel chan SupersimV1NetworkAccessProfile, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan SupersimV1NetworkAccessProfile, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.NetworkAccessProfiles
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListNetworkAccessProfileResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.NetworkAccessProfiles
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListNetworkAccessProfileResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListNetworkAccessProfileResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListNetworkAccessProfileResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListNetworkAccessProfileResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/supersim/v1/sims.go
+++ b/rest/supersim/v1/sims.go
@@ -168,60 +168,70 @@ func (c *ApiService) PageSim(params *ListSimParams, pageToken, pageNumber string
 
 // Lists Sim records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSim(params *ListSimParams) ([]SupersimV1Sim, error) {
-	response, err := c.StreamSim(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamSim(params)
 
 	records := make([]SupersimV1Sim, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Sim records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamSim(params *ListSimParams) (chan SupersimV1Sim, error) {
+func (c *ApiService) StreamSim(params *ListSimParams) (chan SupersimV1Sim, chan error) {
 	if params == nil {
 		params = &ListSimParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan SupersimV1Sim, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageSim(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamSim(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamSim(response *ListSimResponse, params *ListSimParams, recordChannel chan SupersimV1Sim, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan SupersimV1Sim, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Sims
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListSimResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Sims
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListSimResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListSimResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListSimResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListSimResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/supersim/v1/sims_billing_periods.go
+++ b/rest/supersim/v1/sims_billing_periods.go
@@ -74,60 +74,70 @@ func (c *ApiService) PageBillingPeriod(SimSid string, params *ListBillingPeriodP
 
 // Lists BillingPeriod records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListBillingPeriod(SimSid string, params *ListBillingPeriodParams) ([]SupersimV1BillingPeriod, error) {
-	response, err := c.StreamBillingPeriod(SimSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamBillingPeriod(SimSid, params)
 
 	records := make([]SupersimV1BillingPeriod, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams BillingPeriod records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamBillingPeriod(SimSid string, params *ListBillingPeriodParams) (chan SupersimV1BillingPeriod, error) {
+func (c *ApiService) StreamBillingPeriod(SimSid string, params *ListBillingPeriodParams) (chan SupersimV1BillingPeriod, chan error) {
 	if params == nil {
 		params = &ListBillingPeriodParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan SupersimV1BillingPeriod, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageBillingPeriod(SimSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamBillingPeriod(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamBillingPeriod(response *ListBillingPeriodResponse, params *ListBillingPeriodParams, recordChannel chan SupersimV1BillingPeriod, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan SupersimV1BillingPeriod, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.BillingPeriods
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListBillingPeriodResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.BillingPeriods
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListBillingPeriodResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListBillingPeriodResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListBillingPeriodResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListBillingPeriodResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/supersim/v1/sms_commands.go
+++ b/rest/supersim/v1/sms_commands.go
@@ -186,60 +186,70 @@ func (c *ApiService) PageSmsCommand(params *ListSmsCommandParams, pageToken, pag
 
 // Lists SmsCommand records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSmsCommand(params *ListSmsCommandParams) ([]SupersimV1SmsCommand, error) {
-	response, err := c.StreamSmsCommand(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamSmsCommand(params)
 
 	records := make([]SupersimV1SmsCommand, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams SmsCommand records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamSmsCommand(params *ListSmsCommandParams) (chan SupersimV1SmsCommand, error) {
+func (c *ApiService) StreamSmsCommand(params *ListSmsCommandParams) (chan SupersimV1SmsCommand, chan error) {
 	if params == nil {
 		params = &ListSmsCommandParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan SupersimV1SmsCommand, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageSmsCommand(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamSmsCommand(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamSmsCommand(response *ListSmsCommandResponse, params *ListSmsCommandParams, recordChannel chan SupersimV1SmsCommand, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan SupersimV1SmsCommand, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.SmsCommands
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListSmsCommandResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.SmsCommands
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListSmsCommandResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListSmsCommandResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListSmsCommandResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListSmsCommandResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/supersim/v1/usage_records.go
+++ b/rest/supersim/v1/usage_records.go
@@ -144,60 +144,70 @@ func (c *ApiService) PageUsageRecord(params *ListUsageRecordParams, pageToken, p
 
 // Lists UsageRecord records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUsageRecord(params *ListUsageRecordParams) ([]SupersimV1UsageRecord, error) {
-	response, err := c.StreamUsageRecord(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamUsageRecord(params)
 
 	records := make([]SupersimV1UsageRecord, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams UsageRecord records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamUsageRecord(params *ListUsageRecordParams) (chan SupersimV1UsageRecord, error) {
+func (c *ApiService) StreamUsageRecord(params *ListUsageRecordParams) (chan SupersimV1UsageRecord, chan error) {
 	if params == nil {
 		params = &ListUsageRecordParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan SupersimV1UsageRecord, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageUsageRecord(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamUsageRecord(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamUsageRecord(response *ListUsageRecordResponse, params *ListUsageRecordParams, recordChannel chan SupersimV1UsageRecord, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan SupersimV1UsageRecord, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.UsageRecords
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListUsageRecordResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.UsageRecords
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListUsageRecordResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListUsageRecordResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListUsageRecordResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListUsageRecordResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/sync/v1/services.go
+++ b/rest/sync/v1/services.go
@@ -201,60 +201,70 @@ func (c *ApiService) PageService(params *ListServiceParams, pageToken, pageNumbe
 
 // Lists Service records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListService(params *ListServiceParams) ([]SyncV1Service, error) {
-	response, err := c.StreamService(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamService(params)
 
 	records := make([]SyncV1Service, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Service records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamService(params *ListServiceParams) (chan SyncV1Service, error) {
+func (c *ApiService) StreamService(params *ListServiceParams) (chan SyncV1Service, chan error) {
 	if params == nil {
 		params = &ListServiceParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan SyncV1Service, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageService(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamService(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamService(response *ListServiceResponse, params *ListServiceParams, recordChannel chan SyncV1Service, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan SyncV1Service, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Services
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Services
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListServiceResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListServiceResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListServiceResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListServiceResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/sync/v1/services_documents.go
+++ b/rest/sync/v1/services_documents.go
@@ -176,60 +176,70 @@ func (c *ApiService) PageDocument(ServiceSid string, params *ListDocumentParams,
 
 // Lists Document records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListDocument(ServiceSid string, params *ListDocumentParams) ([]SyncV1Document, error) {
-	response, err := c.StreamDocument(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamDocument(ServiceSid, params)
 
 	records := make([]SyncV1Document, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Document records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamDocument(ServiceSid string, params *ListDocumentParams) (chan SyncV1Document, error) {
+func (c *ApiService) StreamDocument(ServiceSid string, params *ListDocumentParams) (chan SyncV1Document, chan error) {
 	if params == nil {
 		params = &ListDocumentParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan SyncV1Document, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageDocument(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamDocument(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamDocument(response *ListDocumentResponse, params *ListDocumentParams, recordChannel chan SyncV1Document, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan SyncV1Document, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Documents
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListDocumentResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Documents
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListDocumentResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListDocumentResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListDocumentResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListDocumentResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/sync/v1/services_lists.go
+++ b/rest/sync/v1/services_lists.go
@@ -170,60 +170,70 @@ func (c *ApiService) PageSyncList(ServiceSid string, params *ListSyncListParams,
 
 // Lists SyncList records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSyncList(ServiceSid string, params *ListSyncListParams) ([]SyncV1SyncList, error) {
-	response, err := c.StreamSyncList(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamSyncList(ServiceSid, params)
 
 	records := make([]SyncV1SyncList, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams SyncList records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamSyncList(ServiceSid string, params *ListSyncListParams) (chan SyncV1SyncList, error) {
+func (c *ApiService) StreamSyncList(ServiceSid string, params *ListSyncListParams) (chan SyncV1SyncList, chan error) {
 	if params == nil {
 		params = &ListSyncListParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan SyncV1SyncList, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageSyncList(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamSyncList(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamSyncList(response *ListSyncListResponse, params *ListSyncListParams, recordChannel chan SyncV1SyncList, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan SyncV1SyncList, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Lists
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListSyncListResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Lists
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListSyncListResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListSyncListResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListSyncListResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListSyncListResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/sync/v1/services_lists_items.go
+++ b/rest/sync/v1/services_lists_items.go
@@ -231,60 +231,70 @@ func (c *ApiService) PageSyncListItem(ServiceSid string, ListSid string, params 
 
 // Lists SyncListItem records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSyncListItem(ServiceSid string, ListSid string, params *ListSyncListItemParams) ([]SyncV1SyncListItem, error) {
-	response, err := c.StreamSyncListItem(ServiceSid, ListSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamSyncListItem(ServiceSid, ListSid, params)
 
 	records := make([]SyncV1SyncListItem, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams SyncListItem records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamSyncListItem(ServiceSid string, ListSid string, params *ListSyncListItemParams) (chan SyncV1SyncListItem, error) {
+func (c *ApiService) StreamSyncListItem(ServiceSid string, ListSid string, params *ListSyncListItemParams) (chan SyncV1SyncListItem, chan error) {
 	if params == nil {
 		params = &ListSyncListItemParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan SyncV1SyncListItem, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageSyncListItem(ServiceSid, ListSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamSyncListItem(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamSyncListItem(response *ListSyncListItemResponse, params *ListSyncListItemParams, recordChannel chan SyncV1SyncListItem, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan SyncV1SyncListItem, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Items
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListSyncListItemResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Items
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListSyncListItemResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListSyncListItemResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListSyncListItemResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListSyncListItemResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/sync/v1/services_lists_permissions.go
+++ b/rest/sync/v1/services_lists_permissions.go
@@ -120,60 +120,70 @@ func (c *ApiService) PageSyncListPermission(ServiceSid string, ListSid string, p
 
 // Lists SyncListPermission records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSyncListPermission(ServiceSid string, ListSid string, params *ListSyncListPermissionParams) ([]SyncV1SyncListPermission, error) {
-	response, err := c.StreamSyncListPermission(ServiceSid, ListSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamSyncListPermission(ServiceSid, ListSid, params)
 
 	records := make([]SyncV1SyncListPermission, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams SyncListPermission records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamSyncListPermission(ServiceSid string, ListSid string, params *ListSyncListPermissionParams) (chan SyncV1SyncListPermission, error) {
+func (c *ApiService) StreamSyncListPermission(ServiceSid string, ListSid string, params *ListSyncListPermissionParams) (chan SyncV1SyncListPermission, chan error) {
 	if params == nil {
 		params = &ListSyncListPermissionParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan SyncV1SyncListPermission, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageSyncListPermission(ServiceSid, ListSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamSyncListPermission(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamSyncListPermission(response *ListSyncListPermissionResponse, params *ListSyncListPermissionParams, recordChannel chan SyncV1SyncListPermission, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan SyncV1SyncListPermission, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Permissions
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListSyncListPermissionResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Permissions
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListSyncListPermissionResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListSyncListPermissionResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListSyncListPermissionResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListSyncListPermissionResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/sync/v1/services_maps.go
+++ b/rest/sync/v1/services_maps.go
@@ -170,60 +170,70 @@ func (c *ApiService) PageSyncMap(ServiceSid string, params *ListSyncMapParams, p
 
 // Lists SyncMap records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSyncMap(ServiceSid string, params *ListSyncMapParams) ([]SyncV1SyncMap, error) {
-	response, err := c.StreamSyncMap(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamSyncMap(ServiceSid, params)
 
 	records := make([]SyncV1SyncMap, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams SyncMap records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamSyncMap(ServiceSid string, params *ListSyncMapParams) (chan SyncV1SyncMap, error) {
+func (c *ApiService) StreamSyncMap(ServiceSid string, params *ListSyncMapParams) (chan SyncV1SyncMap, chan error) {
 	if params == nil {
 		params = &ListSyncMapParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan SyncV1SyncMap, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageSyncMap(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamSyncMap(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamSyncMap(response *ListSyncMapResponse, params *ListSyncMapParams, recordChannel chan SyncV1SyncMap, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan SyncV1SyncMap, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Maps
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListSyncMapResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Maps
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListSyncMapResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListSyncMapResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListSyncMapResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListSyncMapResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/sync/v1/services_maps_items.go
+++ b/rest/sync/v1/services_maps_items.go
@@ -240,60 +240,70 @@ func (c *ApiService) PageSyncMapItem(ServiceSid string, MapSid string, params *L
 
 // Lists SyncMapItem records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSyncMapItem(ServiceSid string, MapSid string, params *ListSyncMapItemParams) ([]SyncV1SyncMapItem, error) {
-	response, err := c.StreamSyncMapItem(ServiceSid, MapSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamSyncMapItem(ServiceSid, MapSid, params)
 
 	records := make([]SyncV1SyncMapItem, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams SyncMapItem records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamSyncMapItem(ServiceSid string, MapSid string, params *ListSyncMapItemParams) (chan SyncV1SyncMapItem, error) {
+func (c *ApiService) StreamSyncMapItem(ServiceSid string, MapSid string, params *ListSyncMapItemParams) (chan SyncV1SyncMapItem, chan error) {
 	if params == nil {
 		params = &ListSyncMapItemParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan SyncV1SyncMapItem, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageSyncMapItem(ServiceSid, MapSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamSyncMapItem(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamSyncMapItem(response *ListSyncMapItemResponse, params *ListSyncMapItemParams, recordChannel chan SyncV1SyncMapItem, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan SyncV1SyncMapItem, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Items
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListSyncMapItemResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Items
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListSyncMapItemResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListSyncMapItemResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListSyncMapItemResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListSyncMapItemResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/sync/v1/services_maps_permissions.go
+++ b/rest/sync/v1/services_maps_permissions.go
@@ -120,60 +120,70 @@ func (c *ApiService) PageSyncMapPermission(ServiceSid string, MapSid string, par
 
 // Lists SyncMapPermission records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSyncMapPermission(ServiceSid string, MapSid string, params *ListSyncMapPermissionParams) ([]SyncV1SyncMapPermission, error) {
-	response, err := c.StreamSyncMapPermission(ServiceSid, MapSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamSyncMapPermission(ServiceSid, MapSid, params)
 
 	records := make([]SyncV1SyncMapPermission, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams SyncMapPermission records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamSyncMapPermission(ServiceSid string, MapSid string, params *ListSyncMapPermissionParams) (chan SyncV1SyncMapPermission, error) {
+func (c *ApiService) StreamSyncMapPermission(ServiceSid string, MapSid string, params *ListSyncMapPermissionParams) (chan SyncV1SyncMapPermission, chan error) {
 	if params == nil {
 		params = &ListSyncMapPermissionParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan SyncV1SyncMapPermission, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageSyncMapPermission(ServiceSid, MapSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamSyncMapPermission(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamSyncMapPermission(response *ListSyncMapPermissionResponse, params *ListSyncMapPermissionParams, recordChannel chan SyncV1SyncMapPermission, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan SyncV1SyncMapPermission, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Permissions
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListSyncMapPermissionResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Permissions
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListSyncMapPermissionResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListSyncMapPermissionResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListSyncMapPermissionResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListSyncMapPermissionResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/sync/v1/services_streams.go
+++ b/rest/sync/v1/services_streams.go
@@ -164,60 +164,70 @@ func (c *ApiService) PageSyncStream(ServiceSid string, params *ListSyncStreamPar
 
 // Lists SyncStream records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSyncStream(ServiceSid string, params *ListSyncStreamParams) ([]SyncV1SyncStream, error) {
-	response, err := c.StreamSyncStream(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamSyncStream(ServiceSid, params)
 
 	records := make([]SyncV1SyncStream, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams SyncStream records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamSyncStream(ServiceSid string, params *ListSyncStreamParams) (chan SyncV1SyncStream, error) {
+func (c *ApiService) StreamSyncStream(ServiceSid string, params *ListSyncStreamParams) (chan SyncV1SyncStream, chan error) {
 	if params == nil {
 		params = &ListSyncStreamParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan SyncV1SyncStream, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageSyncStream(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamSyncStream(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamSyncStream(response *ListSyncStreamResponse, params *ListSyncStreamParams, recordChannel chan SyncV1SyncStream, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan SyncV1SyncStream, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Streams
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListSyncStreamResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Streams
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListSyncStreamResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListSyncStreamResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListSyncStreamResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListSyncStreamResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/taskrouter/v1/workspaces_activities.go
+++ b/rest/taskrouter/v1/workspaces_activities.go
@@ -179,60 +179,70 @@ func (c *ApiService) PageActivity(WorkspaceSid string, params *ListActivityParam
 
 // Lists Activity records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListActivity(WorkspaceSid string, params *ListActivityParams) ([]TaskrouterV1Activity, error) {
-	response, err := c.StreamActivity(WorkspaceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamActivity(WorkspaceSid, params)
 
 	records := make([]TaskrouterV1Activity, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Activity records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamActivity(WorkspaceSid string, params *ListActivityParams) (chan TaskrouterV1Activity, error) {
+func (c *ApiService) StreamActivity(WorkspaceSid string, params *ListActivityParams) (chan TaskrouterV1Activity, chan error) {
 	if params == nil {
 		params = &ListActivityParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TaskrouterV1Activity, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageActivity(WorkspaceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamActivity(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamActivity(response *ListActivityResponse, params *ListActivityParams, recordChannel chan TaskrouterV1Activity, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TaskrouterV1Activity, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Activities
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListActivityResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Activities
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListActivityResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListActivityResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListActivityResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListActivityResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/taskrouter/v1/workspaces_events.go
+++ b/rest/taskrouter/v1/workspaces_events.go
@@ -197,60 +197,70 @@ func (c *ApiService) PageEvent(WorkspaceSid string, params *ListEventParams, pag
 
 // Lists Event records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListEvent(WorkspaceSid string, params *ListEventParams) ([]TaskrouterV1Event, error) {
-	response, err := c.StreamEvent(WorkspaceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamEvent(WorkspaceSid, params)
 
 	records := make([]TaskrouterV1Event, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Event records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamEvent(WorkspaceSid string, params *ListEventParams) (chan TaskrouterV1Event, error) {
+func (c *ApiService) StreamEvent(WorkspaceSid string, params *ListEventParams) (chan TaskrouterV1Event, chan error) {
 	if params == nil {
 		params = &ListEventParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TaskrouterV1Event, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageEvent(WorkspaceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamEvent(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamEvent(response *ListEventResponse, params *ListEventParams, recordChannel chan TaskrouterV1Event, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TaskrouterV1Event, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Events
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListEventResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Events
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListEventResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListEventResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListEventResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListEventResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/taskrouter/v1/workspaces_task_channels.go
+++ b/rest/taskrouter/v1/workspaces_task_channels.go
@@ -170,60 +170,70 @@ func (c *ApiService) PageTaskChannel(WorkspaceSid string, params *ListTaskChanne
 
 // Lists TaskChannel records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListTaskChannel(WorkspaceSid string, params *ListTaskChannelParams) ([]TaskrouterV1TaskChannel, error) {
-	response, err := c.StreamTaskChannel(WorkspaceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamTaskChannel(WorkspaceSid, params)
 
 	records := make([]TaskrouterV1TaskChannel, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams TaskChannel records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamTaskChannel(WorkspaceSid string, params *ListTaskChannelParams) (chan TaskrouterV1TaskChannel, error) {
+func (c *ApiService) StreamTaskChannel(WorkspaceSid string, params *ListTaskChannelParams) (chan TaskrouterV1TaskChannel, chan error) {
 	if params == nil {
 		params = &ListTaskChannelParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TaskrouterV1TaskChannel, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageTaskChannel(WorkspaceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamTaskChannel(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamTaskChannel(response *ListTaskChannelResponse, params *ListTaskChannelParams, recordChannel chan TaskrouterV1TaskChannel, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TaskrouterV1TaskChannel, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Channels
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListTaskChannelResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Channels
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListTaskChannelResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListTaskChannelResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListTaskChannelResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListTaskChannelResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/taskrouter/v1/workspaces_task_queues.go
+++ b/rest/taskrouter/v1/workspaces_task_queues.go
@@ -224,60 +224,70 @@ func (c *ApiService) PageTaskQueue(WorkspaceSid string, params *ListTaskQueuePar
 
 // Lists TaskQueue records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListTaskQueue(WorkspaceSid string, params *ListTaskQueueParams) ([]TaskrouterV1TaskQueue, error) {
-	response, err := c.StreamTaskQueue(WorkspaceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamTaskQueue(WorkspaceSid, params)
 
 	records := make([]TaskrouterV1TaskQueue, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams TaskQueue records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamTaskQueue(WorkspaceSid string, params *ListTaskQueueParams) (chan TaskrouterV1TaskQueue, error) {
+func (c *ApiService) StreamTaskQueue(WorkspaceSid string, params *ListTaskQueueParams) (chan TaskrouterV1TaskQueue, chan error) {
 	if params == nil {
 		params = &ListTaskQueueParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TaskrouterV1TaskQueue, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageTaskQueue(WorkspaceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamTaskQueue(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamTaskQueue(response *ListTaskQueueResponse, params *ListTaskQueueParams, recordChannel chan TaskrouterV1TaskQueue, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TaskrouterV1TaskQueue, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.TaskQueues
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListTaskQueueResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.TaskQueues
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListTaskQueueResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListTaskQueueResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListTaskQueueResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListTaskQueueResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/taskrouter/v1/workspaces_task_queues_statistics.go
+++ b/rest/taskrouter/v1/workspaces_task_queues_statistics.go
@@ -203,60 +203,70 @@ func (c *ApiService) PageTaskQueuesStatistics(WorkspaceSid string, params *ListT
 
 // Lists TaskQueuesStatistics records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListTaskQueuesStatistics(WorkspaceSid string, params *ListTaskQueuesStatisticsParams) ([]TaskrouterV1TaskQueuesStatistics, error) {
-	response, err := c.StreamTaskQueuesStatistics(WorkspaceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamTaskQueuesStatistics(WorkspaceSid, params)
 
 	records := make([]TaskrouterV1TaskQueuesStatistics, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams TaskQueuesStatistics records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamTaskQueuesStatistics(WorkspaceSid string, params *ListTaskQueuesStatisticsParams) (chan TaskrouterV1TaskQueuesStatistics, error) {
+func (c *ApiService) StreamTaskQueuesStatistics(WorkspaceSid string, params *ListTaskQueuesStatisticsParams) (chan TaskrouterV1TaskQueuesStatistics, chan error) {
 	if params == nil {
 		params = &ListTaskQueuesStatisticsParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TaskrouterV1TaskQueuesStatistics, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageTaskQueuesStatistics(WorkspaceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamTaskQueuesStatistics(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamTaskQueuesStatistics(response *ListTaskQueuesStatisticsResponse, params *ListTaskQueuesStatisticsParams, recordChannel chan TaskrouterV1TaskQueuesStatistics, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TaskrouterV1TaskQueuesStatistics, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.TaskQueuesStatistics
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListTaskQueuesStatisticsResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.TaskQueuesStatistics
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListTaskQueuesStatisticsResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListTaskQueuesStatisticsResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListTaskQueuesStatisticsResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListTaskQueuesStatisticsResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/taskrouter/v1/workspaces_workers.go
+++ b/rest/taskrouter/v1/workspaces_workers.go
@@ -248,60 +248,70 @@ func (c *ApiService) PageWorker(WorkspaceSid string, params *ListWorkerParams, p
 
 // Lists Worker records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListWorker(WorkspaceSid string, params *ListWorkerParams) ([]TaskrouterV1Worker, error) {
-	response, err := c.StreamWorker(WorkspaceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamWorker(WorkspaceSid, params)
 
 	records := make([]TaskrouterV1Worker, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Worker records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamWorker(WorkspaceSid string, params *ListWorkerParams) (chan TaskrouterV1Worker, error) {
+func (c *ApiService) StreamWorker(WorkspaceSid string, params *ListWorkerParams) (chan TaskrouterV1Worker, chan error) {
 	if params == nil {
 		params = &ListWorkerParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TaskrouterV1Worker, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageWorker(WorkspaceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamWorker(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamWorker(response *ListWorkerResponse, params *ListWorkerParams, recordChannel chan TaskrouterV1Worker, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TaskrouterV1Worker, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Workers
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListWorkerResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Workers
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListWorkerResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListWorkerResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListWorkerResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListWorkerResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/taskrouter/v1/workspaces_workflows.go
+++ b/rest/taskrouter/v1/workspaces_workflows.go
@@ -197,60 +197,70 @@ func (c *ApiService) PageWorkflow(WorkspaceSid string, params *ListWorkflowParam
 
 // Lists Workflow records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListWorkflow(WorkspaceSid string, params *ListWorkflowParams) ([]TaskrouterV1Workflow, error) {
-	response, err := c.StreamWorkflow(WorkspaceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamWorkflow(WorkspaceSid, params)
 
 	records := make([]TaskrouterV1Workflow, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Workflow records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamWorkflow(WorkspaceSid string, params *ListWorkflowParams) (chan TaskrouterV1Workflow, error) {
+func (c *ApiService) StreamWorkflow(WorkspaceSid string, params *ListWorkflowParams) (chan TaskrouterV1Workflow, chan error) {
 	if params == nil {
 		params = &ListWorkflowParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TaskrouterV1Workflow, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageWorkflow(WorkspaceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamWorkflow(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamWorkflow(response *ListWorkflowResponse, params *ListWorkflowParams, recordChannel chan TaskrouterV1Workflow, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TaskrouterV1Workflow, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Workflows
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListWorkflowResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Workflows
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListWorkflowResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListWorkflowResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListWorkflowResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListWorkflowResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/trunking/v1/trunks.go
+++ b/rest/trunking/v1/trunks.go
@@ -210,60 +210,70 @@ func (c *ApiService) PageTrunk(params *ListTrunkParams, pageToken, pageNumber st
 
 // Lists Trunk records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListTrunk(params *ListTrunkParams) ([]TrunkingV1Trunk, error) {
-	response, err := c.StreamTrunk(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamTrunk(params)
 
 	records := make([]TrunkingV1Trunk, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Trunk records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamTrunk(params *ListTrunkParams) (chan TrunkingV1Trunk, error) {
+func (c *ApiService) StreamTrunk(params *ListTrunkParams) (chan TrunkingV1Trunk, chan error) {
 	if params == nil {
 		params = &ListTrunkParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TrunkingV1Trunk, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageTrunk(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamTrunk(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamTrunk(response *ListTrunkResponse, params *ListTrunkParams, recordChannel chan TrunkingV1Trunk, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TrunkingV1Trunk, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Trunks
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListTrunkResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Trunks
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListTrunkResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListTrunkResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListTrunkResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListTrunkResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/trunking/v1/trunks_credential_lists.go
+++ b/rest/trunking/v1/trunks_credential_lists.go
@@ -152,60 +152,70 @@ func (c *ApiService) PageCredentialList(TrunkSid string, params *ListCredentialL
 
 // Lists CredentialList records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCredentialList(TrunkSid string, params *ListCredentialListParams) ([]TrunkingV1CredentialList, error) {
-	response, err := c.StreamCredentialList(TrunkSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamCredentialList(TrunkSid, params)
 
 	records := make([]TrunkingV1CredentialList, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams CredentialList records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamCredentialList(TrunkSid string, params *ListCredentialListParams) (chan TrunkingV1CredentialList, error) {
+func (c *ApiService) StreamCredentialList(TrunkSid string, params *ListCredentialListParams) (chan TrunkingV1CredentialList, chan error) {
 	if params == nil {
 		params = &ListCredentialListParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TrunkingV1CredentialList, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageCredentialList(TrunkSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamCredentialList(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamCredentialList(response *ListCredentialListResponse, params *ListCredentialListParams, recordChannel chan TrunkingV1CredentialList, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TrunkingV1CredentialList, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.CredentialLists
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListCredentialListResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.CredentialLists
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListCredentialListResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListCredentialListResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListCredentialListResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListCredentialListResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/trunking/v1/trunks_origination_urls.go
+++ b/rest/trunking/v1/trunks_origination_urls.go
@@ -188,60 +188,70 @@ func (c *ApiService) PageOriginationUrl(TrunkSid string, params *ListOrigination
 
 // Lists OriginationUrl records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListOriginationUrl(TrunkSid string, params *ListOriginationUrlParams) ([]TrunkingV1OriginationUrl, error) {
-	response, err := c.StreamOriginationUrl(TrunkSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamOriginationUrl(TrunkSid, params)
 
 	records := make([]TrunkingV1OriginationUrl, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams OriginationUrl records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamOriginationUrl(TrunkSid string, params *ListOriginationUrlParams) (chan TrunkingV1OriginationUrl, error) {
+func (c *ApiService) StreamOriginationUrl(TrunkSid string, params *ListOriginationUrlParams) (chan TrunkingV1OriginationUrl, chan error) {
 	if params == nil {
 		params = &ListOriginationUrlParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TrunkingV1OriginationUrl, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageOriginationUrl(TrunkSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamOriginationUrl(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamOriginationUrl(response *ListOriginationUrlResponse, params *ListOriginationUrlParams, recordChannel chan TrunkingV1OriginationUrl, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TrunkingV1OriginationUrl, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.OriginationUrls
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListOriginationUrlResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.OriginationUrls
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListOriginationUrlResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListOriginationUrlResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListOriginationUrlResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListOriginationUrlResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/trunking/v1/trunks_phone_numbers.go
+++ b/rest/trunking/v1/trunks_phone_numbers.go
@@ -152,60 +152,70 @@ func (c *ApiService) PagePhoneNumber(TrunkSid string, params *ListPhoneNumberPar
 
 // Lists PhoneNumber records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListPhoneNumber(TrunkSid string, params *ListPhoneNumberParams) ([]TrunkingV1PhoneNumber, error) {
-	response, err := c.StreamPhoneNumber(TrunkSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamPhoneNumber(TrunkSid, params)
 
 	records := make([]TrunkingV1PhoneNumber, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams PhoneNumber records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamPhoneNumber(TrunkSid string, params *ListPhoneNumberParams) (chan TrunkingV1PhoneNumber, error) {
+func (c *ApiService) StreamPhoneNumber(TrunkSid string, params *ListPhoneNumberParams) (chan TrunkingV1PhoneNumber, chan error) {
 	if params == nil {
 		params = &ListPhoneNumberParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TrunkingV1PhoneNumber, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PagePhoneNumber(TrunkSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamPhoneNumber(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamPhoneNumber(response *ListPhoneNumberResponse, params *ListPhoneNumberParams, recordChannel chan TrunkingV1PhoneNumber, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TrunkingV1PhoneNumber, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.PhoneNumbers
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListPhoneNumberResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.PhoneNumbers
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListPhoneNumberResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListPhoneNumberResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListPhoneNumberResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListPhoneNumberResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/trusthub/v1/customer_profiles_channel_endpoint_assignments.go
+++ b/rest/trusthub/v1/customer_profiles_channel_endpoint_assignments.go
@@ -182,60 +182,70 @@ func (c *ApiService) PageCustomerProfileChannelEndpointAssignment(CustomerProfil
 
 // Lists CustomerProfileChannelEndpointAssignment records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCustomerProfileChannelEndpointAssignment(CustomerProfileSid string, params *ListCustomerProfileChannelEndpointAssignmentParams) ([]TrusthubV1CustomerProfileChannelEndpointAssignment, error) {
-	response, err := c.StreamCustomerProfileChannelEndpointAssignment(CustomerProfileSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamCustomerProfileChannelEndpointAssignment(CustomerProfileSid, params)
 
 	records := make([]TrusthubV1CustomerProfileChannelEndpointAssignment, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams CustomerProfileChannelEndpointAssignment records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamCustomerProfileChannelEndpointAssignment(CustomerProfileSid string, params *ListCustomerProfileChannelEndpointAssignmentParams) (chan TrusthubV1CustomerProfileChannelEndpointAssignment, error) {
+func (c *ApiService) StreamCustomerProfileChannelEndpointAssignment(CustomerProfileSid string, params *ListCustomerProfileChannelEndpointAssignmentParams) (chan TrusthubV1CustomerProfileChannelEndpointAssignment, chan error) {
 	if params == nil {
 		params = &ListCustomerProfileChannelEndpointAssignmentParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TrusthubV1CustomerProfileChannelEndpointAssignment, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageCustomerProfileChannelEndpointAssignment(CustomerProfileSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamCustomerProfileChannelEndpointAssignment(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamCustomerProfileChannelEndpointAssignment(response *ListCustomerProfileChannelEndpointAssignmentResponse, params *ListCustomerProfileChannelEndpointAssignmentParams, recordChannel chan TrusthubV1CustomerProfileChannelEndpointAssignment, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TrusthubV1CustomerProfileChannelEndpointAssignment, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Results
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListCustomerProfileChannelEndpointAssignmentResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Results
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListCustomerProfileChannelEndpointAssignmentResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListCustomerProfileChannelEndpointAssignmentResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListCustomerProfileChannelEndpointAssignmentResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListCustomerProfileChannelEndpointAssignmentResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/trusthub/v1/customer_profiles_entity_assignments.go
+++ b/rest/trusthub/v1/customer_profiles_entity_assignments.go
@@ -155,60 +155,70 @@ func (c *ApiService) PageCustomerProfileEntityAssignment(CustomerProfileSid stri
 
 // Lists CustomerProfileEntityAssignment records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCustomerProfileEntityAssignment(CustomerProfileSid string, params *ListCustomerProfileEntityAssignmentParams) ([]TrusthubV1CustomerProfileEntityAssignment, error) {
-	response, err := c.StreamCustomerProfileEntityAssignment(CustomerProfileSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamCustomerProfileEntityAssignment(CustomerProfileSid, params)
 
 	records := make([]TrusthubV1CustomerProfileEntityAssignment, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams CustomerProfileEntityAssignment records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamCustomerProfileEntityAssignment(CustomerProfileSid string, params *ListCustomerProfileEntityAssignmentParams) (chan TrusthubV1CustomerProfileEntityAssignment, error) {
+func (c *ApiService) StreamCustomerProfileEntityAssignment(CustomerProfileSid string, params *ListCustomerProfileEntityAssignmentParams) (chan TrusthubV1CustomerProfileEntityAssignment, chan error) {
 	if params == nil {
 		params = &ListCustomerProfileEntityAssignmentParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TrusthubV1CustomerProfileEntityAssignment, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageCustomerProfileEntityAssignment(CustomerProfileSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamCustomerProfileEntityAssignment(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamCustomerProfileEntityAssignment(response *ListCustomerProfileEntityAssignmentResponse, params *ListCustomerProfileEntityAssignmentParams, recordChannel chan TrusthubV1CustomerProfileEntityAssignment, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TrusthubV1CustomerProfileEntityAssignment, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Results
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListCustomerProfileEntityAssignmentResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Results
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListCustomerProfileEntityAssignmentResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListCustomerProfileEntityAssignmentResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListCustomerProfileEntityAssignmentResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListCustomerProfileEntityAssignmentResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/trusthub/v1/end_user_types.go
+++ b/rest/trusthub/v1/end_user_types.go
@@ -95,60 +95,70 @@ func (c *ApiService) PageEndUserType(params *ListEndUserTypeParams, pageToken, p
 
 // Lists EndUserType records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListEndUserType(params *ListEndUserTypeParams) ([]TrusthubV1EndUserType, error) {
-	response, err := c.StreamEndUserType(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamEndUserType(params)
 
 	records := make([]TrusthubV1EndUserType, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams EndUserType records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamEndUserType(params *ListEndUserTypeParams) (chan TrusthubV1EndUserType, error) {
+func (c *ApiService) StreamEndUserType(params *ListEndUserTypeParams) (chan TrusthubV1EndUserType, chan error) {
 	if params == nil {
 		params = &ListEndUserTypeParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TrusthubV1EndUserType, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageEndUserType(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamEndUserType(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamEndUserType(response *ListEndUserTypeResponse, params *ListEndUserTypeParams, recordChannel chan TrusthubV1EndUserType, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TrusthubV1EndUserType, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.EndUserTypes
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListEndUserTypeResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.EndUserTypes
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListEndUserTypeResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListEndUserTypeResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListEndUserTypeResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListEndUserTypeResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/trusthub/v1/end_users.go
+++ b/rest/trusthub/v1/end_users.go
@@ -174,60 +174,70 @@ func (c *ApiService) PageEndUser(params *ListEndUserParams, pageToken, pageNumbe
 
 // Lists EndUser records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListEndUser(params *ListEndUserParams) ([]TrusthubV1EndUser, error) {
-	response, err := c.StreamEndUser(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamEndUser(params)
 
 	records := make([]TrusthubV1EndUser, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams EndUser records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamEndUser(params *ListEndUserParams) (chan TrusthubV1EndUser, error) {
+func (c *ApiService) StreamEndUser(params *ListEndUserParams) (chan TrusthubV1EndUser, chan error) {
 	if params == nil {
 		params = &ListEndUserParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TrusthubV1EndUser, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageEndUser(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamEndUser(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamEndUser(response *ListEndUserResponse, params *ListEndUserParams, recordChannel chan TrusthubV1EndUser, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TrusthubV1EndUser, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Results
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListEndUserResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Results
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListEndUserResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListEndUserResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListEndUserResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListEndUserResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/trusthub/v1/policies.go
+++ b/rest/trusthub/v1/policies.go
@@ -95,60 +95,70 @@ func (c *ApiService) PagePolicies(params *ListPoliciesParams, pageToken, pageNum
 
 // Lists Policies records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListPolicies(params *ListPoliciesParams) ([]TrusthubV1Policies, error) {
-	response, err := c.StreamPolicies(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamPolicies(params)
 
 	records := make([]TrusthubV1Policies, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Policies records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamPolicies(params *ListPoliciesParams) (chan TrusthubV1Policies, error) {
+func (c *ApiService) StreamPolicies(params *ListPoliciesParams) (chan TrusthubV1Policies, chan error) {
 	if params == nil {
 		params = &ListPoliciesParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TrusthubV1Policies, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PagePolicies(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamPolicies(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamPolicies(response *ListPoliciesResponse, params *ListPoliciesParams, recordChannel chan TrusthubV1Policies, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TrusthubV1Policies, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Results
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListPoliciesResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Results
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListPoliciesResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListPoliciesResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListPoliciesResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListPoliciesResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/trusthub/v1/supporting_documents.go
+++ b/rest/trusthub/v1/supporting_documents.go
@@ -174,60 +174,70 @@ func (c *ApiService) PageSupportingDocument(params *ListSupportingDocumentParams
 
 // Lists SupportingDocument records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListSupportingDocument(params *ListSupportingDocumentParams) ([]TrusthubV1SupportingDocument, error) {
-	response, err := c.StreamSupportingDocument(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamSupportingDocument(params)
 
 	records := make([]TrusthubV1SupportingDocument, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams SupportingDocument records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamSupportingDocument(params *ListSupportingDocumentParams) (chan TrusthubV1SupportingDocument, error) {
+func (c *ApiService) StreamSupportingDocument(params *ListSupportingDocumentParams) (chan TrusthubV1SupportingDocument, chan error) {
 	if params == nil {
 		params = &ListSupportingDocumentParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TrusthubV1SupportingDocument, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageSupportingDocument(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamSupportingDocument(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamSupportingDocument(response *ListSupportingDocumentResponse, params *ListSupportingDocumentParams, recordChannel chan TrusthubV1SupportingDocument, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TrusthubV1SupportingDocument, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Results
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListSupportingDocumentResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Results
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListSupportingDocumentResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListSupportingDocumentResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListSupportingDocumentResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListSupportingDocumentResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/trusthub/v1/trust_products.go
+++ b/rest/trusthub/v1/trust_products.go
@@ -204,60 +204,70 @@ func (c *ApiService) PageTrustProduct(params *ListTrustProductParams, pageToken,
 
 // Lists TrustProduct records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListTrustProduct(params *ListTrustProductParams) ([]TrusthubV1TrustProduct, error) {
-	response, err := c.StreamTrustProduct(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamTrustProduct(params)
 
 	records := make([]TrusthubV1TrustProduct, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams TrustProduct records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamTrustProduct(params *ListTrustProductParams) (chan TrusthubV1TrustProduct, error) {
+func (c *ApiService) StreamTrustProduct(params *ListTrustProductParams) (chan TrusthubV1TrustProduct, chan error) {
 	if params == nil {
 		params = &ListTrustProductParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TrusthubV1TrustProduct, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageTrustProduct(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamTrustProduct(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamTrustProduct(response *ListTrustProductResponse, params *ListTrustProductParams, recordChannel chan TrusthubV1TrustProduct, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TrusthubV1TrustProduct, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Results
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListTrustProductResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Results
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListTrustProductResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListTrustProductResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListTrustProductResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListTrustProductResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/trusthub/v1/trust_products_channel_endpoint_assignments.go
+++ b/rest/trusthub/v1/trust_products_channel_endpoint_assignments.go
@@ -182,60 +182,70 @@ func (c *ApiService) PageTrustProductChannelEndpointAssignment(TrustProductSid s
 
 // Lists TrustProductChannelEndpointAssignment records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListTrustProductChannelEndpointAssignment(TrustProductSid string, params *ListTrustProductChannelEndpointAssignmentParams) ([]TrusthubV1TrustProductChannelEndpointAssignment, error) {
-	response, err := c.StreamTrustProductChannelEndpointAssignment(TrustProductSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamTrustProductChannelEndpointAssignment(TrustProductSid, params)
 
 	records := make([]TrusthubV1TrustProductChannelEndpointAssignment, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams TrustProductChannelEndpointAssignment records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamTrustProductChannelEndpointAssignment(TrustProductSid string, params *ListTrustProductChannelEndpointAssignmentParams) (chan TrusthubV1TrustProductChannelEndpointAssignment, error) {
+func (c *ApiService) StreamTrustProductChannelEndpointAssignment(TrustProductSid string, params *ListTrustProductChannelEndpointAssignmentParams) (chan TrusthubV1TrustProductChannelEndpointAssignment, chan error) {
 	if params == nil {
 		params = &ListTrustProductChannelEndpointAssignmentParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TrusthubV1TrustProductChannelEndpointAssignment, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageTrustProductChannelEndpointAssignment(TrustProductSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamTrustProductChannelEndpointAssignment(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamTrustProductChannelEndpointAssignment(response *ListTrustProductChannelEndpointAssignmentResponse, params *ListTrustProductChannelEndpointAssignmentParams, recordChannel chan TrusthubV1TrustProductChannelEndpointAssignment, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TrusthubV1TrustProductChannelEndpointAssignment, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Results
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListTrustProductChannelEndpointAssignmentResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Results
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListTrustProductChannelEndpointAssignmentResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListTrustProductChannelEndpointAssignmentResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListTrustProductChannelEndpointAssignmentResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListTrustProductChannelEndpointAssignmentResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/trusthub/v1/trust_products_entity_assignments.go
+++ b/rest/trusthub/v1/trust_products_entity_assignments.go
@@ -155,60 +155,70 @@ func (c *ApiService) PageTrustProductEntityAssignment(TrustProductSid string, pa
 
 // Lists TrustProductEntityAssignment records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListTrustProductEntityAssignment(TrustProductSid string, params *ListTrustProductEntityAssignmentParams) ([]TrusthubV1TrustProductEntityAssignment, error) {
-	response, err := c.StreamTrustProductEntityAssignment(TrustProductSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamTrustProductEntityAssignment(TrustProductSid, params)
 
 	records := make([]TrusthubV1TrustProductEntityAssignment, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams TrustProductEntityAssignment records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamTrustProductEntityAssignment(TrustProductSid string, params *ListTrustProductEntityAssignmentParams) (chan TrusthubV1TrustProductEntityAssignment, error) {
+func (c *ApiService) StreamTrustProductEntityAssignment(TrustProductSid string, params *ListTrustProductEntityAssignmentParams) (chan TrusthubV1TrustProductEntityAssignment, chan error) {
 	if params == nil {
 		params = &ListTrustProductEntityAssignmentParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TrusthubV1TrustProductEntityAssignment, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageTrustProductEntityAssignment(TrustProductSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamTrustProductEntityAssignment(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamTrustProductEntityAssignment(response *ListTrustProductEntityAssignmentResponse, params *ListTrustProductEntityAssignmentParams, recordChannel chan TrusthubV1TrustProductEntityAssignment, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TrusthubV1TrustProductEntityAssignment, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Results
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListTrustProductEntityAssignmentResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Results
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListTrustProductEntityAssignmentResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListTrustProductEntityAssignmentResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListTrustProductEntityAssignmentResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListTrustProductEntityAssignmentResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/trusthub/v1/trust_products_evaluations.go
+++ b/rest/trusthub/v1/trust_products_evaluations.go
@@ -136,60 +136,70 @@ func (c *ApiService) PageTrustProductEvaluation(TrustProductSid string, params *
 
 // Lists TrustProductEvaluation records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListTrustProductEvaluation(TrustProductSid string, params *ListTrustProductEvaluationParams) ([]TrusthubV1TrustProductEvaluation, error) {
-	response, err := c.StreamTrustProductEvaluation(TrustProductSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamTrustProductEvaluation(TrustProductSid, params)
 
 	records := make([]TrusthubV1TrustProductEvaluation, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams TrustProductEvaluation records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamTrustProductEvaluation(TrustProductSid string, params *ListTrustProductEvaluationParams) (chan TrusthubV1TrustProductEvaluation, error) {
+func (c *ApiService) StreamTrustProductEvaluation(TrustProductSid string, params *ListTrustProductEvaluationParams) (chan TrusthubV1TrustProductEvaluation, chan error) {
 	if params == nil {
 		params = &ListTrustProductEvaluationParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TrusthubV1TrustProductEvaluation, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageTrustProductEvaluation(TrustProductSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamTrustProductEvaluation(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamTrustProductEvaluation(response *ListTrustProductEvaluationResponse, params *ListTrustProductEvaluationParams, recordChannel chan TrusthubV1TrustProductEvaluation, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TrusthubV1TrustProductEvaluation, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Results
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListTrustProductEvaluationResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Results
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListTrustProductEvaluationResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListTrustProductEvaluationResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListTrustProductEvaluationResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListTrustProductEvaluationResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/verify/v2/services.go
+++ b/rest/verify/v2/services.go
@@ -294,60 +294,70 @@ func (c *ApiService) PageService(params *ListServiceParams, pageToken, pageNumbe
 
 // Lists Service records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListService(params *ListServiceParams) ([]VerifyV2Service, error) {
-	response, err := c.StreamService(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamService(params)
 
 	records := make([]VerifyV2Service, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Service records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamService(params *ListServiceParams) (chan VerifyV2Service, error) {
+func (c *ApiService) StreamService(params *ListServiceParams) (chan VerifyV2Service, chan error) {
 	if params == nil {
 		params = &ListServiceParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan VerifyV2Service, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageService(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamService(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamService(response *ListServiceResponse, params *ListServiceParams, recordChannel chan VerifyV2Service, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan VerifyV2Service, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Services
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListServiceResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Services
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListServiceResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListServiceResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListServiceResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListServiceResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/verify/v2/services_entities_challenges.go
+++ b/rest/verify/v2/services_entities_challenges.go
@@ -226,60 +226,70 @@ func (c *ApiService) PageChallenge(ServiceSid string, Identity string, params *L
 
 // Lists Challenge records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListChallenge(ServiceSid string, Identity string, params *ListChallengeParams) ([]VerifyV2Challenge, error) {
-	response, err := c.StreamChallenge(ServiceSid, Identity, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamChallenge(ServiceSid, Identity, params)
 
 	records := make([]VerifyV2Challenge, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Challenge records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamChallenge(ServiceSid string, Identity string, params *ListChallengeParams) (chan VerifyV2Challenge, error) {
+func (c *ApiService) StreamChallenge(ServiceSid string, Identity string, params *ListChallengeParams) (chan VerifyV2Challenge, chan error) {
 	if params == nil {
 		params = &ListChallengeParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan VerifyV2Challenge, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageChallenge(ServiceSid, Identity, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamChallenge(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamChallenge(response *ListChallengeResponse, params *ListChallengeParams, recordChannel chan VerifyV2Challenge, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan VerifyV2Challenge, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Challenges
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListChallengeResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Challenges
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListChallengeResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListChallengeResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListChallengeResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListChallengeResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/verify/v2/services_entities_factors.go
+++ b/rest/verify/v2/services_entities_factors.go
@@ -282,60 +282,70 @@ func (c *ApiService) PageFactor(ServiceSid string, Identity string, params *List
 
 // Lists Factor records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListFactor(ServiceSid string, Identity string, params *ListFactorParams) ([]VerifyV2Factor, error) {
-	response, err := c.StreamFactor(ServiceSid, Identity, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamFactor(ServiceSid, Identity, params)
 
 	records := make([]VerifyV2Factor, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Factor records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamFactor(ServiceSid string, Identity string, params *ListFactorParams) (chan VerifyV2Factor, error) {
+func (c *ApiService) StreamFactor(ServiceSid string, Identity string, params *ListFactorParams) (chan VerifyV2Factor, chan error) {
 	if params == nil {
 		params = &ListFactorParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan VerifyV2Factor, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageFactor(ServiceSid, Identity, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamFactor(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamFactor(response *ListFactorResponse, params *ListFactorParams, recordChannel chan VerifyV2Factor, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan VerifyV2Factor, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Factors
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListFactorResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Factors
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListFactorResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListFactorResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListFactorResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListFactorResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/verify/v2/services_rate_limits.go
+++ b/rest/verify/v2/services_rate_limits.go
@@ -164,60 +164,70 @@ func (c *ApiService) PageRateLimit(ServiceSid string, params *ListRateLimitParam
 
 // Lists RateLimit records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRateLimit(ServiceSid string, params *ListRateLimitParams) ([]VerifyV2RateLimit, error) {
-	response, err := c.StreamRateLimit(ServiceSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamRateLimit(ServiceSid, params)
 
 	records := make([]VerifyV2RateLimit, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams RateLimit records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamRateLimit(ServiceSid string, params *ListRateLimitParams) (chan VerifyV2RateLimit, error) {
+func (c *ApiService) StreamRateLimit(ServiceSid string, params *ListRateLimitParams) (chan VerifyV2RateLimit, chan error) {
 	if params == nil {
 		params = &ListRateLimitParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan VerifyV2RateLimit, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageRateLimit(ServiceSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamRateLimit(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamRateLimit(response *ListRateLimitResponse, params *ListRateLimitParams, recordChannel chan VerifyV2RateLimit, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan VerifyV2RateLimit, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.RateLimits
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListRateLimitResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.RateLimits
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListRateLimitResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListRateLimitResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListRateLimitResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListRateLimitResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/verify/v2/templates.go
+++ b/rest/verify/v2/templates.go
@@ -80,60 +80,70 @@ func (c *ApiService) PageVerificationTemplate(params *ListVerificationTemplatePa
 
 // Lists VerificationTemplate records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListVerificationTemplate(params *ListVerificationTemplateParams) ([]VerifyV2VerificationTemplate, error) {
-	response, err := c.StreamVerificationTemplate(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamVerificationTemplate(params)
 
 	records := make([]VerifyV2VerificationTemplate, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams VerificationTemplate records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamVerificationTemplate(params *ListVerificationTemplateParams) (chan VerifyV2VerificationTemplate, error) {
+func (c *ApiService) StreamVerificationTemplate(params *ListVerificationTemplateParams) (chan VerifyV2VerificationTemplate, chan error) {
 	if params == nil {
 		params = &ListVerificationTemplateParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan VerifyV2VerificationTemplate, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageVerificationTemplate(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamVerificationTemplate(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamVerificationTemplate(response *ListVerificationTemplateResponse, params *ListVerificationTemplateParams, recordChannel chan VerifyV2VerificationTemplate, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan VerifyV2VerificationTemplate, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Templates
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListVerificationTemplateResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Templates
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListVerificationTemplateResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListVerificationTemplateResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListVerificationTemplateResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListVerificationTemplateResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/video/v1/recordings.go
+++ b/rest/video/v1/recordings.go
@@ -170,60 +170,70 @@ func (c *ApiService) PageRecording(params *ListRecordingParams, pageToken, pageN
 
 // Lists Recording records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRecording(params *ListRecordingParams) ([]VideoV1Recording, error) {
-	response, err := c.StreamRecording(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamRecording(params)
 
 	records := make([]VideoV1Recording, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Recording records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamRecording(params *ListRecordingParams) (chan VideoV1Recording, error) {
+func (c *ApiService) StreamRecording(params *ListRecordingParams) (chan VideoV1Recording, chan error) {
 	if params == nil {
 		params = &ListRecordingParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan VideoV1Recording, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageRecording(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamRecording(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamRecording(response *ListRecordingResponse, params *ListRecordingParams, recordChannel chan VideoV1Recording, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan VideoV1Recording, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Recordings
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListRecordingResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Recordings
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListRecordingResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListRecordingResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListRecordingResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListRecordingResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/video/v1/rooms_participants_subscribed_tracks.go
+++ b/rest/video/v1/rooms_participants_subscribed_tracks.go
@@ -100,60 +100,70 @@ func (c *ApiService) PageRoomParticipantSubscribedTrack(RoomSid string, Particip
 
 // Lists RoomParticipantSubscribedTrack records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRoomParticipantSubscribedTrack(RoomSid string, ParticipantSid string, params *ListRoomParticipantSubscribedTrackParams) ([]VideoV1RoomParticipantSubscribedTrack, error) {
-	response, err := c.StreamRoomParticipantSubscribedTrack(RoomSid, ParticipantSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamRoomParticipantSubscribedTrack(RoomSid, ParticipantSid, params)
 
 	records := make([]VideoV1RoomParticipantSubscribedTrack, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams RoomParticipantSubscribedTrack records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamRoomParticipantSubscribedTrack(RoomSid string, ParticipantSid string, params *ListRoomParticipantSubscribedTrackParams) (chan VideoV1RoomParticipantSubscribedTrack, error) {
+func (c *ApiService) StreamRoomParticipantSubscribedTrack(RoomSid string, ParticipantSid string, params *ListRoomParticipantSubscribedTrackParams) (chan VideoV1RoomParticipantSubscribedTrack, chan error) {
 	if params == nil {
 		params = &ListRoomParticipantSubscribedTrackParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan VideoV1RoomParticipantSubscribedTrack, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageRoomParticipantSubscribedTrack(RoomSid, ParticipantSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamRoomParticipantSubscribedTrack(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamRoomParticipantSubscribedTrack(response *ListRoomParticipantSubscribedTrackResponse, params *ListRoomParticipantSubscribedTrackParams, recordChannel chan VideoV1RoomParticipantSubscribedTrack, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan VideoV1RoomParticipantSubscribedTrack, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.SubscribedTracks
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListRoomParticipantSubscribedTrackResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.SubscribedTracks
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListRoomParticipantSubscribedTrackResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListRoomParticipantSubscribedTrackResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListRoomParticipantSubscribedTrackResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListRoomParticipantSubscribedTrackResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/voice/v1/byoc_trunks.go
+++ b/rest/voice/v1/byoc_trunks.go
@@ -228,60 +228,70 @@ func (c *ApiService) PageByocTrunk(params *ListByocTrunkParams, pageToken, pageN
 
 // Lists ByocTrunk records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListByocTrunk(params *ListByocTrunkParams) ([]VoiceV1ByocTrunk, error) {
-	response, err := c.StreamByocTrunk(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamByocTrunk(params)
 
 	records := make([]VoiceV1ByocTrunk, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ByocTrunk records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamByocTrunk(params *ListByocTrunkParams) (chan VoiceV1ByocTrunk, error) {
+func (c *ApiService) StreamByocTrunk(params *ListByocTrunkParams) (chan VoiceV1ByocTrunk, chan error) {
 	if params == nil {
 		params = &ListByocTrunkParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan VoiceV1ByocTrunk, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageByocTrunk(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamByocTrunk(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamByocTrunk(response *ListByocTrunkResponse, params *ListByocTrunkParams, recordChannel chan VoiceV1ByocTrunk, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan VoiceV1ByocTrunk, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.ByocTrunks
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListByocTrunkResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.ByocTrunks
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListByocTrunkResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListByocTrunkResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListByocTrunkResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListByocTrunkResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/voice/v1/connection_policies.go
+++ b/rest/voice/v1/connection_policies.go
@@ -147,60 +147,70 @@ func (c *ApiService) PageConnectionPolicy(params *ListConnectionPolicyParams, pa
 
 // Lists ConnectionPolicy records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListConnectionPolicy(params *ListConnectionPolicyParams) ([]VoiceV1ConnectionPolicy, error) {
-	response, err := c.StreamConnectionPolicy(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamConnectionPolicy(params)
 
 	records := make([]VoiceV1ConnectionPolicy, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ConnectionPolicy records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamConnectionPolicy(params *ListConnectionPolicyParams) (chan VoiceV1ConnectionPolicy, error) {
+func (c *ApiService) StreamConnectionPolicy(params *ListConnectionPolicyParams) (chan VoiceV1ConnectionPolicy, chan error) {
 	if params == nil {
 		params = &ListConnectionPolicyParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan VoiceV1ConnectionPolicy, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageConnectionPolicy(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamConnectionPolicy(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamConnectionPolicy(response *ListConnectionPolicyResponse, params *ListConnectionPolicyParams, recordChannel chan VoiceV1ConnectionPolicy, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan VoiceV1ConnectionPolicy, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.ConnectionPolicies
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListConnectionPolicyResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.ConnectionPolicies
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListConnectionPolicyResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListConnectionPolicyResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListConnectionPolicyResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListConnectionPolicyResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/voice/v1/connection_policies_targets.go
+++ b/rest/voice/v1/connection_policies_targets.go
@@ -188,60 +188,70 @@ func (c *ApiService) PageConnectionPolicyTarget(ConnectionPolicySid string, para
 
 // Lists ConnectionPolicyTarget records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListConnectionPolicyTarget(ConnectionPolicySid string, params *ListConnectionPolicyTargetParams) ([]VoiceV1ConnectionPolicyTarget, error) {
-	response, err := c.StreamConnectionPolicyTarget(ConnectionPolicySid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamConnectionPolicyTarget(ConnectionPolicySid, params)
 
 	records := make([]VoiceV1ConnectionPolicyTarget, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams ConnectionPolicyTarget records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamConnectionPolicyTarget(ConnectionPolicySid string, params *ListConnectionPolicyTargetParams) (chan VoiceV1ConnectionPolicyTarget, error) {
+func (c *ApiService) StreamConnectionPolicyTarget(ConnectionPolicySid string, params *ListConnectionPolicyTargetParams) (chan VoiceV1ConnectionPolicyTarget, chan error) {
 	if params == nil {
 		params = &ListConnectionPolicyTargetParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan VoiceV1ConnectionPolicyTarget, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageConnectionPolicyTarget(ConnectionPolicySid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamConnectionPolicyTarget(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamConnectionPolicyTarget(response *ListConnectionPolicyTargetResponse, params *ListConnectionPolicyTargetParams, recordChannel chan VoiceV1ConnectionPolicyTarget, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan VoiceV1ConnectionPolicyTarget, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Targets
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListConnectionPolicyTargetResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Targets
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListConnectionPolicyTargetResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListConnectionPolicyTargetResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListConnectionPolicyTargetResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListConnectionPolicyTargetResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/voice/v1/dialing_permissions_countries.go
+++ b/rest/voice/v1/dialing_permissions_countries.go
@@ -149,60 +149,70 @@ func (c *ApiService) PageDialingPermissionsCountry(params *ListDialingPermission
 
 // Lists DialingPermissionsCountry records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListDialingPermissionsCountry(params *ListDialingPermissionsCountryParams) ([]VoiceV1DialingPermissionsCountry, error) {
-	response, err := c.StreamDialingPermissionsCountry(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamDialingPermissionsCountry(params)
 
 	records := make([]VoiceV1DialingPermissionsCountry, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams DialingPermissionsCountry records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamDialingPermissionsCountry(params *ListDialingPermissionsCountryParams) (chan VoiceV1DialingPermissionsCountry, error) {
+func (c *ApiService) StreamDialingPermissionsCountry(params *ListDialingPermissionsCountryParams) (chan VoiceV1DialingPermissionsCountry, chan error) {
 	if params == nil {
 		params = &ListDialingPermissionsCountryParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan VoiceV1DialingPermissionsCountry, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageDialingPermissionsCountry(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamDialingPermissionsCountry(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamDialingPermissionsCountry(response *ListDialingPermissionsCountryResponse, params *ListDialingPermissionsCountryParams, recordChannel chan VoiceV1DialingPermissionsCountry, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan VoiceV1DialingPermissionsCountry, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Content
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListDialingPermissionsCountryResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Content
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListDialingPermissionsCountryResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListDialingPermissionsCountryResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListDialingPermissionsCountryResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListDialingPermissionsCountryResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/voice/v1/dialing_permissions_countries_high_risk_special_prefixes.go
+++ b/rest/voice/v1/dialing_permissions_countries_high_risk_special_prefixes.go
@@ -74,60 +74,70 @@ func (c *ApiService) PageDialingPermissionsHrsPrefixes(IsoCode string, params *L
 
 // Lists DialingPermissionsHrsPrefixes records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListDialingPermissionsHrsPrefixes(IsoCode string, params *ListDialingPermissionsHrsPrefixesParams) ([]VoiceV1DialingPermissionsHrsPrefixes, error) {
-	response, err := c.StreamDialingPermissionsHrsPrefixes(IsoCode, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamDialingPermissionsHrsPrefixes(IsoCode, params)
 
 	records := make([]VoiceV1DialingPermissionsHrsPrefixes, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams DialingPermissionsHrsPrefixes records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamDialingPermissionsHrsPrefixes(IsoCode string, params *ListDialingPermissionsHrsPrefixesParams) (chan VoiceV1DialingPermissionsHrsPrefixes, error) {
+func (c *ApiService) StreamDialingPermissionsHrsPrefixes(IsoCode string, params *ListDialingPermissionsHrsPrefixesParams) (chan VoiceV1DialingPermissionsHrsPrefixes, chan error) {
 	if params == nil {
 		params = &ListDialingPermissionsHrsPrefixesParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan VoiceV1DialingPermissionsHrsPrefixes, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageDialingPermissionsHrsPrefixes(IsoCode, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamDialingPermissionsHrsPrefixes(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamDialingPermissionsHrsPrefixes(response *ListDialingPermissionsHrsPrefixesResponse, params *ListDialingPermissionsHrsPrefixesParams, recordChannel chan VoiceV1DialingPermissionsHrsPrefixes, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan VoiceV1DialingPermissionsHrsPrefixes, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Content
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListDialingPermissionsHrsPrefixesResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Content
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListDialingPermissionsHrsPrefixesResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListDialingPermissionsHrsPrefixesResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListDialingPermissionsHrsPrefixesResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListDialingPermissionsHrsPrefixesResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/voice/v1/ip_records.go
+++ b/rest/voice/v1/ip_records.go
@@ -165,60 +165,70 @@ func (c *ApiService) PageIpRecord(params *ListIpRecordParams, pageToken, pageNum
 
 // Lists IpRecord records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListIpRecord(params *ListIpRecordParams) ([]VoiceV1IpRecord, error) {
-	response, err := c.StreamIpRecord(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamIpRecord(params)
 
 	records := make([]VoiceV1IpRecord, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams IpRecord records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamIpRecord(params *ListIpRecordParams) (chan VoiceV1IpRecord, error) {
+func (c *ApiService) StreamIpRecord(params *ListIpRecordParams) (chan VoiceV1IpRecord, chan error) {
 	if params == nil {
 		params = &ListIpRecordParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan VoiceV1IpRecord, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageIpRecord(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamIpRecord(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamIpRecord(response *ListIpRecordResponse, params *ListIpRecordParams, recordChannel chan VoiceV1IpRecord, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan VoiceV1IpRecord, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.IpRecords
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListIpRecordResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.IpRecords
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListIpRecordResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListIpRecordResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListIpRecordResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListIpRecordResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/wireless/v1/commands.go
+++ b/rest/wireless/v1/commands.go
@@ -240,60 +240,70 @@ func (c *ApiService) PageCommand(params *ListCommandParams, pageToken, pageNumbe
 
 // Lists Command records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCommand(params *ListCommandParams) ([]WirelessV1Command, error) {
-	response, err := c.StreamCommand(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamCommand(params)
 
 	records := make([]WirelessV1Command, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams Command records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamCommand(params *ListCommandParams) (chan WirelessV1Command, error) {
+func (c *ApiService) StreamCommand(params *ListCommandParams) (chan WirelessV1Command, chan error) {
 	if params == nil {
 		params = &ListCommandParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan WirelessV1Command, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageCommand(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamCommand(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamCommand(response *ListCommandResponse, params *ListCommandParams, recordChannel chan WirelessV1Command, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan WirelessV1Command, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Commands
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListCommandResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Commands
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListCommandResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListCommandResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListCommandResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListCommandResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/wireless/v1/rate_plans.go
+++ b/rest/wireless/v1/rate_plans.go
@@ -239,60 +239,70 @@ func (c *ApiService) PageRatePlan(params *ListRatePlanParams, pageToken, pageNum
 
 // Lists RatePlan records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListRatePlan(params *ListRatePlanParams) ([]WirelessV1RatePlan, error) {
-	response, err := c.StreamRatePlan(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamRatePlan(params)
 
 	records := make([]WirelessV1RatePlan, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams RatePlan records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamRatePlan(params *ListRatePlanParams) (chan WirelessV1RatePlan, error) {
+func (c *ApiService) StreamRatePlan(params *ListRatePlanParams) (chan WirelessV1RatePlan, chan error) {
 	if params == nil {
 		params = &ListRatePlanParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan WirelessV1RatePlan, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageRatePlan(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamRatePlan(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamRatePlan(response *ListRatePlanResponse, params *ListRatePlanParams, recordChannel chan WirelessV1RatePlan, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan WirelessV1RatePlan, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.RatePlans
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListRatePlanResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.RatePlans
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListRatePlanResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListRatePlanResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListRatePlanResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListRatePlanResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/wireless/v1/sims_usage_records.go
+++ b/rest/wireless/v1/sims_usage_records.go
@@ -102,60 +102,70 @@ func (c *ApiService) PageUsageRecord(SimSid string, params *ListUsageRecordParam
 
 // Lists UsageRecord records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListUsageRecord(SimSid string, params *ListUsageRecordParams) ([]WirelessV1UsageRecord, error) {
-	response, err := c.StreamUsageRecord(SimSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamUsageRecord(SimSid, params)
 
 	records := make([]WirelessV1UsageRecord, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams UsageRecord records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamUsageRecord(SimSid string, params *ListUsageRecordParams) (chan WirelessV1UsageRecord, error) {
+func (c *ApiService) StreamUsageRecord(SimSid string, params *ListUsageRecordParams) (chan WirelessV1UsageRecord, chan error) {
 	if params == nil {
 		params = &ListUsageRecordParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan WirelessV1UsageRecord, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageUsageRecord(SimSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamUsageRecord(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamUsageRecord(response *ListUsageRecordResponse, params *ListUsageRecordParams, recordChannel chan WirelessV1UsageRecord, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan WirelessV1UsageRecord, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.UsageRecords
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListUsageRecordResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.UsageRecords
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListUsageRecordResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListUsageRecordResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListUsageRecordResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListUsageRecordResponse(nextPageUrl string) (interface{}, error) {

--- a/rest/wireless/v1/usage_records.go
+++ b/rest/wireless/v1/usage_records.go
@@ -99,60 +99,70 @@ func (c *ApiService) PageAccountUsageRecord(params *ListAccountUsageRecordParams
 
 // Lists AccountUsageRecord records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListAccountUsageRecord(params *ListAccountUsageRecordParams) ([]WirelessV1AccountUsageRecord, error) {
-	response, err := c.StreamAccountUsageRecord(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamAccountUsageRecord(params)
 
 	records := make([]WirelessV1AccountUsageRecord, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams AccountUsageRecord records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamAccountUsageRecord(params *ListAccountUsageRecordParams) (chan WirelessV1AccountUsageRecord, error) {
+func (c *ApiService) StreamAccountUsageRecord(params *ListAccountUsageRecordParams) (chan WirelessV1AccountUsageRecord, chan error) {
 	if params == nil {
 		params = &ListAccountUsageRecordParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan WirelessV1AccountUsageRecord, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageAccountUsageRecord(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamAccountUsageRecord(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamAccountUsageRecord(response *ListAccountUsageRecordResponse, params *ListAccountUsageRecordParams, recordChannel chan WirelessV1AccountUsageRecord, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan WirelessV1AccountUsageRecord, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.UsageRecords
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListAccountUsageRecordResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.UsageRecords
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListAccountUsageRecordResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListAccountUsageRecordResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListAccountUsageRecordResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListAccountUsageRecordResponse(nextPageUrl string) (interface{}, error) {


### PR DESCRIPTION
This allows for pushing errors while paginating.

Relates to https://github.com/twilio/twilio-oai-generator/pull/131

Fixes https://github.com/twilio/twilio-go/issues/157