### PR TITLE
chore: retract v1.22.0 due to known bug

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -45,7 +45,7 @@ jobs:
         run: make test
 
       - name: Run Cluster Tests
-        if: (!github.event.pull_request.head.repo.fork)
+        if: (!github.event.pull_request.head.repo.fork) && matrix.go != '1.15'  # Breaking changes in golang 1.16 cause some unit test files to be invalid.
         env:
           TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
           TWILIO_API_KEY: ${{ secrets.TWILIO_CLUSTER_TEST_API_KEY}}

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -37,6 +37,7 @@ jobs:
           only-new-issues: true
 
       - name: Build
+        if: matrix.go != '1.15'  # Breaking changes in golang 1.16 cause some unit test files to be invalid.
         run: make install
 
       - name: Run Unit Tests

--- a/go.mod
+++ b/go.mod
@@ -14,3 +14,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )
+
+retract (
+    v1.22.0 // Contains known bug
+)

--- a/go.mod
+++ b/go.mod
@@ -14,3 +14,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )
+
+retract (
+    v1.22.0 // Published accidentally.
+)

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,3 @@ require (
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )
-
-retract (
-    v1.22.0 // Contains known bug
-)

--- a/go.mod
+++ b/go.mod
@@ -16,5 +16,5 @@ require (
 )
 
 retract (
-    v1.22.0 // Published accidentally.
+    v1.22.0 // Contains known bug
 )


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2

Note: If you made changes to the Request Validation logic, please run `make webhook-cluster-test` locally and ensure all test cases pass
-->

# Fixes #251 

The v1.22.0 needs to retracted as the go proxy does not reflect the fix made after the release. After doing this, we will be releasing a new tag which will work as the latest tag. Following this [guide](https://go.dev/ref/mod#go-mod-file-retract).

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-go/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
