### PR TITLE
feat: Add support for passing a Go Context when making an API request

### DIFF
--- a/client/base_client.go
+++ b/client/base_client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"time"
@@ -13,4 +14,10 @@ type BaseClient interface {
 		headers map[string]interface{}, body ...byte) (*http.Response, error)
 	SetOauth(auth OAuth)
 	OAuth() OAuth
+}
+
+type BaseClientWithContext interface {
+	BaseClient
+	SendRequestWithContext(ctx context.Context, method string, rawURL string, data url.Values,
+		headers map[string]interface{}, body ...byte) (*http.Response, error)
 }

--- a/client/page_util.go
+++ b/client/page_util.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -25,13 +26,17 @@ func ReadLimits(pageSize *int, limit *int) int {
 	}
 }
 
-func GetNext(baseUrl string, response interface{}, getNextPage func(nextPageUri string) (interface{}, error)) (interface{}, error) {
+func GetNext(baseUrl string, response interface{}, getNextPage func(ctx context.Context, nextPageUri string) (interface{}, error)) (interface{}, error) {
+	return GetNextWithContext(context.Background(), baseUrl, response, getNextPage)
+}
+
+func GetNextWithContext(ctx context.Context, baseUrl string, response interface{}, getNextPage func(ctx context.Context, nextPageUri string) (interface{}, error)) (interface{}, error) {
 	nextPageUrl, err := getNextPageUrl(baseUrl, response)
 	if err != nil {
 		return nil, err
 	}
 
-	return getNextPage(nextPageUrl)
+	return getNextPage(ctx, nextPageUrl)
 }
 
 func toMap(s interface{}) (map[string]interface{}, error) {

--- a/client/page_util_test.go
+++ b/client/page_util_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -140,7 +141,7 @@ type testMessage struct {
 	To *string `json:"to,omitempty"`
 }
 
-func getSomething(nextPageUrl string) (interface{}, error) {
+func getSomething(ctx context.Context, nextPageUrl string) (interface{}, error) {
 	return nextPageUrl, nil
 }
 
@@ -151,11 +152,11 @@ func TestPageUtil_GetNext(t *testing.T) {
 	ps := &testResponse{}
 	_ = json.NewDecoder(response.Body).Decode(ps)
 
-	nextPageUrl, err := GetNext(baseUrl, ps, getSomething)
+	nextPageUrl, err := GetNextWithContext(context.Background(), baseUrl, ps, getSomething)
 	assert.Equal(t, "https://api.twilio.com/2010-04-01/Accounts/ACXX/Messages.json?From=9999999999&PageNumber=&To=4444444444&PageSize=2&Page=1&PageToken=PASMXX", nextPageUrl)
 	assert.Nil(t, err)
 
-	nextPageUrl, err = GetNext(baseUrl, nil, getSomething)
+	nextPageUrl, err = GetNextWithContext(context.Background(), baseUrl, nil, getSomething)
 	assert.Empty(t, nextPageUrl)
 	assert.Nil(t, err)
 }

--- a/client/request_handler_test.go
+++ b/client/request_handler_test.go
@@ -1,6 +1,7 @@
 package client_test
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -83,7 +84,7 @@ func TestRequestHandler_SendGetRequest(t *testing.T) {
 	defer errorServer.Close()
 
 	requestHandler := NewRequestHandler("user", "pass")
-	resp, err := requestHandler.Get(errorServer.URL, nil, nil) //nolint:bodyclose
+	resp, err := requestHandler.GetWithContext(context.Background(), errorServer.URL, nil, nil) //nolint:bodyclose
 	twilioError := err.(*client.TwilioRestError)
 	assert.Nil(t, resp)
 	assert.Equal(t, 400, twilioError.Status)
@@ -108,7 +109,7 @@ func TestRequestHandler_SendPostRequest(t *testing.T) {
 	defer errorServer.Close()
 
 	requestHandler := NewRequestHandler("user", "pass")
-	resp, err := requestHandler.Post(errorServer.URL, nil, nil) //nolint:bodyclose
+	resp, err := requestHandler.PostWithContext(context.Background(), errorServer.URL, nil, nil) //nolint:bodyclose
 	twilioError := err.(*client.TwilioRestError)
 	assert.Nil(t, resp)
 	assert.Equal(t, 400, twilioError.Status)

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -4,6 +4,7 @@
 package twilio
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -15,6 +16,7 @@ import (
 	EventsV1 "github.com/twilio/twilio-go/rest/events/v1"
 
 	"github.com/stretchr/testify/assert"
+
 	IamV1 "github.com/twilio/twilio-go/rest/iam/v1"
 )
 
@@ -267,4 +269,27 @@ func TestOrgsScimUerList(t *testing.T) {
 	users, err := orgsClient.PreviewIamOrganization.ListOrganizationUsers(orgSid, &PreviewIam.ListOrganizationUsersParams{})
 	assert.Nil(t, err)
 	assert.NotNil(t, users)
+}
+
+func TestSendingATextWithContext(t *testing.T) {
+	params := &Api.CreateMessageParams{}
+	params.SetTo(to)
+	params.SetFrom(from)
+	params.SetBody("Hello there")
+
+	resp, err := testClient.Api.CreateMessageWithContext(context.Background(), params)
+	assert.Nil(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, "Hello there", *resp.Body)
+	assert.Equal(t, from, *resp.From)
+	assert.Equal(t, to, *resp.To)
+}
+
+func TestOrgsAccountsListWithContext(t *testing.T) {
+	listAccounts, err := orgsClient.PreviewIamOrganization.ListOrganizationAccountsWithContext(context.Background(), orgSid, &PreviewIam.ListOrganizationAccountsParams{})
+	assert.Nil(t, err)
+	assert.NotNil(t, listAccounts)
+	accounts, err := orgsClient.PreviewIamOrganization.FetchOrganizationAccountWithContext(context.Background(), orgSid, &PreviewIam.FetchOrganizationAccountParams{PathAccountSid: &accountSidOrgs})
+	assert.Nil(t, err)
+	assert.NotNil(t, accounts)
 }

--- a/oauth.go
+++ b/oauth.go
@@ -100,7 +100,7 @@ func (a *APIOAuth) GetAccessToken(ctx context.Context) (string, error) {
 		SetClientId(a.creds.ClientId).
 		SetClientSecret(a.creds.ClientSecret)
 	a.iamService.RequestHandler().Client.SetOauth(nil) // set oauth to nil to make no-auth request
-	token, err := a.iamService.CreateToken(params)
+	token, err := a.iamService.CreateTokenWithContext(ctx, params)
 	if err == nil {
 		a.tokenAuth = TokenAuth{
 			Token: *token.AccessToken,


### PR DESCRIPTION
# Fixes #

This PR adds support for passing a Go Context when making an API request. All API methods will now have a matching function for passing a Go Context when make the API request. For example, the Taskrouter Workspaces `CreateTask` function will now have a corresponding `CreateTaskWithContext` method that accepts a Go `context.Context` as its first parameter.

- I have a separate PR in twilio-oai-generator: https://github.com/twilio/twilio-oai-generator/pull/683
- This PR does not include code changes generated from twilio-oai-generator.
   - I can add the generated code to this branch/PR or a separate branch/PR if that will make code review easier.
- I still need to add tests and docs, but I wanted to get feedback and ensure the concept of this PR makes sense before putting more work into it.

Closes #255. Supersedes #287. Supersedes #290.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-go/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified
