### PR TITLE
feat: Add Tags and MessageIntent params to CreateMessage

### DIFF
--- a/rest/api/v2010/accounts_messages.go
+++ b/rest/api/v2010/accounts_messages.go
@@ -77,8 +77,10 @@ type CreateMessageParams struct {
 	MediaUrl *[]string `json:"MediaUrl,omitempty"`
 	// For [Content Editor/API](https://www.twilio.com/docs/content) only: The SID of the Content Template to be used with the Message, e.g., `HXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`. If this parameter is not provided, a Content Template is not used. Find the SID in the Console on the Content Editor page. For Content API users, the SID is found in Twilio's response when [creating the Template](https://www.twilio.com/docs/content/content-api-resources#create-templates) or by [fetching your Templates](https://www.twilio.com/docs/content/content-api-resources#fetch-all-content-resources).
 	ContentSid *string `json:"ContentSid,omitempty"`
-	// Tags is a private beta feature, which is switched on for Recart
+	// Tags allows setting key-value metadata on the message
 	Tags *map[string]string `json:"Tags,omitempty"`
+	// MessageIntent is to assign a Traffic Shaping Service Level
+	MessageIntent *string `json:"MessageIntent,omitempty"`
 }
 
 func (params *CreateMessageParams) SetPathAccountSid(PathAccountSid string) *CreateMessageParams {
@@ -185,6 +187,10 @@ func (params *CreateMessageParams) SetTags(Tags map[string]string) *CreateMessag
 	params.Tags = &Tags
 	return params
 }
+func (params *CreateMessageParams) SetMessageIntent(MessageIntent string) *CreateMessageParams {
+	params.MessageIntent = &MessageIntent
+	return params
+}
 
 // Send a message
 func (c *ApiService) CreateMessage(params *CreateMessageParams) (*ApiV2010Message, error) {
@@ -283,6 +289,9 @@ func (c *ApiService) CreateMessage(params *CreateMessageParams) (*ApiV2010Messag
 		}
 
 		data.Set("Tags", string(res))
+	}
+	if params != nil && params.MessageIntent != nil {
+		data.Set("MessageIntent", *params.MessageIntent)
 	}
 
 	resp, err := c.requestHandler.Post(c.baseURL+path, data, headers)

--- a/rest/api/v2010/accounts_messages.go
+++ b/rest/api/v2010/accounts_messages.go
@@ -77,6 +77,8 @@ type CreateMessageParams struct {
 	MediaUrl *[]string `json:"MediaUrl,omitempty"`
 	// For [Content Editor/API](https://www.twilio.com/docs/content) only: The SID of the Content Template to be used with the Message, e.g., `HXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`. If this parameter is not provided, a Content Template is not used. Find the SID in the Console on the Content Editor page. For Content API users, the SID is found in Twilio's response when [creating the Template](https://www.twilio.com/docs/content/content-api-resources#create-templates) or by [fetching your Templates](https://www.twilio.com/docs/content/content-api-resources#fetch-all-content-resources).
 	ContentSid *string `json:"ContentSid,omitempty"`
+	// Tags is a private beta feature, which is switched on for Recart
+	Tags *map[string]string `json:"Tags,omitempty"`
 }
 
 func (params *CreateMessageParams) SetPathAccountSid(PathAccountSid string) *CreateMessageParams {
@@ -179,6 +181,10 @@ func (params *CreateMessageParams) SetContentSid(ContentSid string) *CreateMessa
 	params.ContentSid = &ContentSid
 	return params
 }
+func (params *CreateMessageParams) SetTags(Tags map[string]string) *CreateMessageParams {
+	params.Tags = &Tags
+	return params
+}
 
 // Send a message
 func (c *ApiService) CreateMessage(params *CreateMessageParams) (*ApiV2010Message, error) {
@@ -269,6 +275,14 @@ func (c *ApiService) CreateMessage(params *CreateMessageParams) (*ApiV2010Messag
 	}
 	if params != nil && params.ContentSid != nil {
 		data.Set("ContentSid", *params.ContentSid)
+	}
+	if params != nil && params.Tags != nil {
+		res, err := json.Marshal(*params.Tags)
+		if err != nil {
+			return nil, err
+		}
+
+		data.Set("Tags", string(res))
 	}
 
 	resp, err := c.requestHandler.Post(c.baseURL+path, data, headers)

--- a/rest/api/v2010/model_api_v2010_message.go
+++ b/rest/api/v2010/model_api_v2010_message.go
@@ -54,4 +54,5 @@ type ApiV2010Message struct {
 	ApiVersion *string `json:"api_version,omitempty"`
 	// A list of related resources identified by their URIs relative to `https://api.twilio.com`
 	SubresourceUris *map[string]interface{} `json:"subresource_uris,omitempty"`
+	Tags            *map[string]string      `json:"tags,omitempty"`
 }


### PR DESCRIPTION
## Summary
- Add `Tags` parameter to `CreateMessage` request, allowing key-value string pairs to be sent as JSON-encoded form data
- Add `Tags` field to `ApiV2010Message` response model for deserialization
- Add `MessageIntent` parameter to `CreateMessage` request, enabling assignment of a Traffic Shaping Service Level

## Test plan
- [x] `make test` passes with all existing tests
- [x] Verify `Tags` parameter is correctly JSON-serialized and sent as form data
- [x] Verify `MessageIntent` parameter is sent as a string form field
- [x] Verify `Tags` field is correctly deserialized from API responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)