### PR TITLE
fix: pass apiVersion via object

### DIFF
--- a/client/request_handler.go
+++ b/client/request_handler.go
@@ -9,10 +9,9 @@ import (
 )
 
 type RequestHandler struct {
-	Client     BaseClient
-	Edge       string
-	Region     string
-	ApiVersion string // Stores the API version (e.g., "v1.0") for the service
+	Client BaseClient
+	Edge   string
+	Region string
 }
 
 func NewRequestHandler(client BaseClient) *RequestHandler {
@@ -23,16 +22,11 @@ func NewRequestHandler(client BaseClient) *RequestHandler {
 	}
 }
 
-// SetApiVersion sets the API version for the service
-func (c *RequestHandler) SetApiVersion(apiVersion string) {
-	c.ApiVersion = apiVersion
-}
-
 func (c *RequestHandler) sendRequest(method string, rawURL string, data url.Values,
-	headers map[string]interface{}, body ...byte) (*http.Response, error) {
-	// If API version is set, add it to request headers
-	if c.ApiVersion != "" && headers != nil {
-		headers["X-Twilio-ApiVersion"] = c.ApiVersion
+	headers map[string]interface{}, apiVersion string, body ...byte) (*http.Response, error) {
+	// If API version is provided, add it to request headers
+	if apiVersion != "" && headers != nil {
+		headers["X-Twilio-ApiVersion"] = apiVersion
 	}
 	parsedURL, err := c.BuildUrl(rawURL)
 	if err != nil {
@@ -92,22 +86,22 @@ func (c *RequestHandler) BuildUrl(rawURL string) (string, error) {
 	return u.String(), nil
 }
 
-func (c *RequestHandler) Post(path string, bodyData url.Values, headers map[string]interface{}, body ...byte) (*http.Response, error) {
-	return c.sendRequest(http.MethodPost, path, bodyData, headers, body...)
+func (c *RequestHandler) Post(path string, bodyData url.Values, headers map[string]interface{}, apiVersion string, body ...byte) (*http.Response, error) {
+	return c.sendRequest(http.MethodPost, path, bodyData, headers, apiVersion, body...)
 }
 
-func (c *RequestHandler) Put(path string, bodyData url.Values, headers map[string]interface{}, body ...byte) (*http.Response, error) {
-	return c.sendRequest(http.MethodPut, path, bodyData, headers, body...)
+func (c *RequestHandler) Put(path string, bodyData url.Values, headers map[string]interface{}, apiVersion string, body ...byte) (*http.Response, error) {
+	return c.sendRequest(http.MethodPut, path, bodyData, headers, apiVersion, body...)
 }
 
-func (c *RequestHandler) Patch(path string, bodyData url.Values, headers map[string]interface{}, body ...byte) (*http.Response, error) {
-	return c.sendRequest(http.MethodPatch, path, bodyData, headers, body...)
+func (c *RequestHandler) Patch(path string, bodyData url.Values, headers map[string]interface{}, apiVersion string, body ...byte) (*http.Response, error) {
+	return c.sendRequest(http.MethodPatch, path, bodyData, headers, apiVersion, body...)
 }
 
-func (c *RequestHandler) Get(path string, queryData url.Values, headers map[string]interface{}) (*http.Response, error) {
-	return c.sendRequest(http.MethodGet, path, queryData, headers)
+func (c *RequestHandler) Get(path string, queryData url.Values, headers map[string]interface{}, apiVersion string) (*http.Response, error) {
+	return c.sendRequest(http.MethodGet, path, queryData, headers, apiVersion)
 }
 
-func (c *RequestHandler) Delete(path string, queryData url.Values, headers map[string]interface{}) (*http.Response, error) {
-	return c.sendRequest(http.MethodDelete, path, queryData, headers)
+func (c *RequestHandler) Delete(path string, queryData url.Values, headers map[string]interface{}, apiVersion string) (*http.Response, error) {
+	return c.sendRequest(http.MethodDelete, path, queryData, headers, apiVersion)
 }

--- a/client/request_handler_test.go
+++ b/client/request_handler_test.go
@@ -83,7 +83,7 @@ func TestRequestHandler_SendGetRequest(t *testing.T) {
 	defer errorServer.Close()
 
 	requestHandler := NewRequestHandler("user", "pass")
-	resp, err := requestHandler.Get(errorServer.URL, nil, nil) //nolint:bodyclose
+	resp, err := requestHandler.Get(errorServer.URL, nil, nil, "") //nolint:bodyclose
 	twilioError := err.(*client.TwilioRestError)
 	assert.Nil(t, resp)
 	assert.Equal(t, 400, twilioError.Status)
@@ -108,7 +108,7 @@ func TestRequestHandler_SendPostRequest(t *testing.T) {
 	defer errorServer.Close()
 
 	requestHandler := NewRequestHandler("user", "pass")
-	resp, err := requestHandler.Post(errorServer.URL, nil, nil) //nolint:bodyclose
+	resp, err := requestHandler.Post(errorServer.URL, nil, nil, "") //nolint:bodyclose
 	twilioError := err.(*client.TwilioRestError)
 	assert.Nil(t, resp)
 	assert.Equal(t, 400, twilioError.Status)


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2

Note: If you made changes to the Request Validation logic, please run `make webhook-cluster-test` locally and ensure all test cases pass
-->

# Fixes #

Issue - https://github.com/twilio/twilio-go/issues/320
apiVersion was getting set in 1 object and shared among them all.
Now, apiVersion will be part of apiService.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-go/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
