### PR TITLE
feat: Add auto-retry with exponential backoff for 429 responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,28 @@ This will result in the `hostname` transforming from `api.twilio.com` to `api.sy
 
 A Twilio client constructed without these parameters will also look for `TWILIO_REGION` and `TWILIO_EDGE` variables inside the current environment.
 
+### Enable Auto-Retry with Exponential Backoff
+
+`twilio-go` supports automatic retry with exponential backoff when API requests receive an [Error 429 response](https://support.twilio.com/hc/en-us/articles/360044308153-Twilio-API-response-Error-429-Too-Many-Requests-). This retry with exponential backoff feature is disabled by default. To enable this feature, instantiate the Twilio client and call `SetAutoRetry(true)`.
+
+You may customize the retry behavior with the following methods:
+
+- **`SetMaxRetries(int)`**: Set the maximum number of retry attempts (default: `3`)
+- **`SetMaxRetryDelay(int)`**: Set the maximum retry delay in milliseconds (default: `3000`)
+
+```go
+package main
+
+import (
+	"github.com/twilio/twilio-go"
+)
+
+func main() {
+	client := twilio.NewRestClient()
+	client.SetAutoRetry(true)
+}
+```
+
 ### Buy a phone number
 
 ```go

--- a/client/base_client.go
+++ b/client/base_client.go
@@ -13,4 +13,7 @@ type BaseClient interface {
 		headers map[string]interface{}, body ...byte) (*http.Response, error)
 	SetOauth(auth OAuth)
 	OAuth() OAuth
+	SetAutoRetry(autoRetry bool)
+	SetMaxRetryDelay(maxRetryDelay int)
+	SetMaxRetries(maxRetries int)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -25,6 +27,7 @@ var delimitingRegex *regexp.Regexp
 func init() {
 	alphanumericRegex = regexp.MustCompile(`^[a-zA-Z0-9]*$`)
 	delimitingRegex = regexp.MustCompile(`\.\d+`)
+	rand.Seed(time.Now().UnixNano())
 }
 
 // Credentials store user authentication credentials.
@@ -48,6 +51,12 @@ type Client struct {
 	accountSid          string
 	UserAgentExtensions []string
 	oAuth               OAuth
+	// AutoRetry enables automatic retry with exponential backoff on 429 responses
+	AutoRetry bool
+	// MaxRetryDelay is the maximum retry delay in milliseconds for 429 responses
+	MaxRetryDelay int
+	// MaxRetries is the maximum number of request retries for 429 responses
+	MaxRetries int
 }
 
 // default http Client should not follow redirects and return the most recent response.
@@ -81,14 +90,21 @@ func extractContentTypeHeader(headers map[string]interface{}) (cType string) {
 }
 
 const (
-	urlEncodedContentType = "application/x-www-form-urlencoded"
-	jsonContentType       = "application/json"
-	keepZeros             = true
-	delimiter             = '.'
-	escapee               = '\\'
+	urlEncodedContentType            = "application/x-www-form-urlencoded"
+	jsonContentType                  = "application/json"
+	keepZeros                        = true
+	delimiter                        = '.'
+	escapee                          = '\\'
+	defaultInitialRetryIntervalMillis = 100
+	defaultMaxRetryDelay              = 3000
+	defaultMaxRetries                 = 3
 )
 
 func (c *Client) doWithErr(req *http.Request) (*http.Response, error) {
+	return c.doWithErrAndRetry(req, 0)
+}
+
+func (c *Client) doWithErrAndRetry(req *http.Request, retryCount int) (*http.Response, error) {
 	client := c.HTTPClient
 
 	if client == nil {
@@ -98,6 +114,36 @@ func (c *Client) doWithErr(req *http.Request) (*http.Response, error) {
 	res, err := client.Do(req)
 	if err != nil {
 		return nil, err
+	}
+
+	// Handle 429 responses with retry if AutoRetry is enabled
+	if res.StatusCode == http.StatusTooManyRequests && c.AutoRetry {
+		maxRetries := c.MaxRetries
+		if maxRetries == 0 {
+			maxRetries = defaultMaxRetries
+		}
+
+		if retryCount < maxRetries {
+			res.Body.Close()
+
+			// Calculate exponential backoff delay with full jitter
+			maxRetryDelay := c.MaxRetryDelay
+			if maxRetryDelay == 0 {
+				maxRetryDelay = defaultMaxRetryDelay
+			}
+
+			baseDelay := math.Min(
+				float64(maxRetryDelay),
+				float64(defaultInitialRetryIntervalMillis)*math.Pow(2, float64(retryCount+1)),
+			)
+			// Full jitter: random delay between 0 and baseDelay
+			delay := time.Duration(rand.Float64()*baseDelay) * time.Millisecond
+
+			time.Sleep(delay)
+
+			// Retry the request
+			return c.doWithErrAndRetry(req, retryCount+1)
+		}
 	}
 
 	// Note that 3XX response codes are allowed for fetches
@@ -253,4 +299,21 @@ func (c *Client) SetOauth(oauth OAuth) {
 
 func (c *Client) OAuth() OAuth {
 	return c.oAuth
+}
+
+// SetAutoRetry enables or disables automatic retry with exponential backoff on 429 responses.
+func (c *Client) SetAutoRetry(autoRetry bool) {
+	c.AutoRetry = autoRetry
+}
+
+// SetMaxRetryDelay sets the maximum retry delay in milliseconds for 429 responses.
+// Defaults to 3000ms if not set.
+func (c *Client) SetMaxRetryDelay(maxRetryDelay int) {
+	c.MaxRetryDelay = maxRetryDelay
+}
+
+// SetMaxRetries sets the maximum number of request retries for 429 responses.
+// Defaults to 3 if not set.
+func (c *Client) SetMaxRetries(maxRetries int) {
+	c.MaxRetries = maxRetries
 }

--- a/client/mock_client.go
+++ b/client/mock_client.go
@@ -100,3 +100,39 @@ func (mr *MockBaseClientMockRecorder) OAuth() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOauth", reflect.TypeOf((*MockBaseClient)(nil).OAuth))
 }
+
+// SetAutoRetry mocks base method.
+func (m *MockBaseClient) SetAutoRetry(autoRetry bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetAutoRetry", autoRetry)
+}
+
+// SetAutoRetry indicates an expected call of SetAutoRetry.
+func (mr *MockBaseClientMockRecorder) SetAutoRetry(autoRetry interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAutoRetry", reflect.TypeOf((*MockBaseClient)(nil).SetAutoRetry), autoRetry)
+}
+
+// SetMaxRetryDelay mocks base method.
+func (m *MockBaseClient) SetMaxRetryDelay(maxRetryDelay int) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetMaxRetryDelay", maxRetryDelay)
+}
+
+// SetMaxRetryDelay indicates an expected call of SetMaxRetryDelay.
+func (mr *MockBaseClientMockRecorder) SetMaxRetryDelay(maxRetryDelay interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMaxRetryDelay", reflect.TypeOf((*MockBaseClient)(nil).SetMaxRetryDelay), maxRetryDelay)
+}
+
+// SetMaxRetries mocks base method.
+func (m *MockBaseClient) SetMaxRetries(maxRetries int) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetMaxRetries", maxRetries)
+}
+
+// SetMaxRetries indicates an expected call of SetMaxRetries.
+func (mr *MockBaseClientMockRecorder) SetMaxRetries(maxRetries interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMaxRetries", reflect.TypeOf((*MockBaseClient)(nil).SetMaxRetries), maxRetries)
+}

--- a/client/retry_test.go
+++ b/client/retry_test.go
@@ -1,0 +1,232 @@
+package client_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/twilio/twilio-go/client"
+)
+
+func TestClient_AutoRetryDisabled(t *testing.T) {
+	// Create a server that always returns 429
+	requestCount := int32(0)
+	server := httptest.NewServer(http.HandlerFunc(
+		func(writer http.ResponseWriter, request *http.Request) {
+			atomic.AddInt32(&requestCount, 1)
+			writer.WriteHeader(http.StatusTooManyRequests)
+			_, _ = writer.Write([]byte(`{"status": 429, "code": 20429, "message": "Too Many Requests", "more_info": "https://www.twilio.com/docs/errors/20429"}`))
+		}))
+	defer server.Close()
+
+	c := NewClient("user", "pass")
+	c.AutoRetry = false // Explicitly disable auto-retry
+
+	_, err := c.SendRequest("GET", server.URL, nil, nil) //nolint:bodyclose
+	assert.Error(t, err)
+	twilioError := err.(*client.TwilioRestError)
+	assert.Equal(t, 429, twilioError.Status)
+	assert.Equal(t, 20429, twilioError.Code)
+
+	// Should only make one request
+	assert.Equal(t, int32(1), atomic.LoadInt32(&requestCount))
+}
+
+func TestClient_AutoRetryEnabledEventualSuccess(t *testing.T) {
+	// Create a server that returns 429 twice, then succeeds
+	requestCount := int32(0)
+	server := httptest.NewServer(http.HandlerFunc(
+		func(writer http.ResponseWriter, request *http.Request) {
+			count := atomic.AddInt32(&requestCount, 1)
+			if count <= 2 {
+				writer.WriteHeader(http.StatusTooManyRequests)
+				_, _ = writer.Write([]byte(`{"status": 429, "code": 20429, "message": "Too Many Requests", "more_info": "https://www.twilio.com/docs/errors/20429"}`))
+			} else {
+				writer.WriteHeader(http.StatusOK)
+				d := map[string]interface{}{"response": "ok"}
+				_ = json.NewEncoder(writer).Encode(&d)
+			}
+		}))
+	defer server.Close()
+
+	c := NewClient("user", "pass")
+	c.SetAutoRetry(true)
+	c.SetMaxRetries(3)
+	c.SetMaxRetryDelay(100) // Short delay for testing
+
+	start := time.Now()
+	resp, err := c.SendRequest("GET", server.URL, nil, nil) //nolint:bodyclose
+	elapsed := time.Since(start)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Should make 3 requests total (2 failures + 1 success)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&requestCount))
+
+	// Should have waited for retries (at least some time but not too long)
+	assert.Greater(t, elapsed, time.Duration(0))
+	assert.Less(t, elapsed, 2*time.Second) // Should be much faster with our short delay
+}
+
+func TestClient_AutoRetryMaxRetriesExceeded(t *testing.T) {
+	// Create a server that always returns 429
+	requestCount := int32(0)
+	server := httptest.NewServer(http.HandlerFunc(
+		func(writer http.ResponseWriter, request *http.Request) {
+			atomic.AddInt32(&requestCount, 1)
+			writer.WriteHeader(http.StatusTooManyRequests)
+			_, _ = writer.Write([]byte(`{"status": 429, "code": 20429, "message": "Too Many Requests", "more_info": "https://www.twilio.com/docs/errors/20429"}`))
+		}))
+	defer server.Close()
+
+	c := NewClient("user", "pass")
+	c.SetAutoRetry(true)
+	c.SetMaxRetries(3)
+	c.SetMaxRetryDelay(50) // Very short delay for testing
+
+	_, err := c.SendRequest("GET", server.URL, nil, nil) //nolint:bodyclose
+	assert.Error(t, err)
+	twilioError := err.(*client.TwilioRestError)
+	assert.Equal(t, 429, twilioError.Status)
+	assert.Equal(t, 20429, twilioError.Code)
+
+	// Should make 4 requests total (initial + 3 retries)
+	assert.Equal(t, int32(4), atomic.LoadInt32(&requestCount))
+}
+
+func TestClient_AutoRetryCustomMaxRetries(t *testing.T) {
+	// Create a server that always returns 429
+	requestCount := int32(0)
+	server := httptest.NewServer(http.HandlerFunc(
+		func(writer http.ResponseWriter, request *http.Request) {
+			atomic.AddInt32(&requestCount, 1)
+			writer.WriteHeader(http.StatusTooManyRequests)
+			_, _ = writer.Write([]byte(`{"status": 429, "code": 20429, "message": "Too Many Requests", "more_info": "https://www.twilio.com/docs/errors/20429"}`))
+		}))
+	defer server.Close()
+
+	c := NewClient("user", "pass")
+	c.SetAutoRetry(true)
+	c.SetMaxRetries(5) // Custom max retries
+	c.SetMaxRetryDelay(50)
+
+	_, err := c.SendRequest("GET", server.URL, nil, nil) //nolint:bodyclose
+	assert.Error(t, err)
+	twilioError := err.(*client.TwilioRestError)
+	assert.Equal(t, 429, twilioError.Status)
+
+	// Should make 6 requests total (initial + 5 retries)
+	assert.Equal(t, int32(6), atomic.LoadInt32(&requestCount))
+}
+
+func TestClient_AutoRetryOnlyRetries429(t *testing.T) {
+	// Create a server that returns a different error code
+	requestCount := int32(0)
+	server := httptest.NewServer(http.HandlerFunc(
+		func(writer http.ResponseWriter, request *http.Request) {
+			atomic.AddInt32(&requestCount, 1)
+			writer.WriteHeader(http.StatusBadRequest) // 400, not 429
+			_, _ = writer.Write([]byte(`{"status": 400, "code": 20001, "message": "Bad request", "more_info": "https://www.twilio.com/docs/errors/20001"}`))
+		}))
+	defer server.Close()
+
+	c := NewClient("user", "pass")
+	c.SetAutoRetry(true)
+	c.SetMaxRetries(3)
+
+	_, err := c.SendRequest("GET", server.URL, nil, nil) //nolint:bodyclose
+	assert.Error(t, err)
+	twilioError := err.(*client.TwilioRestError)
+	assert.Equal(t, 400, twilioError.Status)
+	assert.Equal(t, 20001, twilioError.Code)
+
+	// Should only make one request (no retries for non-429 errors)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&requestCount))
+}
+
+func TestClient_AutoRetryDefaultValues(t *testing.T) {
+	// Create a server that always returns 429
+	requestCount := int32(0)
+	server := httptest.NewServer(http.HandlerFunc(
+		func(writer http.ResponseWriter, request *http.Request) {
+			atomic.AddInt32(&requestCount, 1)
+			writer.WriteHeader(http.StatusTooManyRequests)
+			_, _ = writer.Write([]byte(`{"status": 429, "code": 20429, "message": "Too Many Requests", "more_info": "https://www.twilio.com/docs/errors/20429"}`))
+		}))
+	defer server.Close()
+
+	c := NewClient("user", "pass")
+	c.SetAutoRetry(true)
+	// Don't set MaxRetries or MaxRetryDelay - should use defaults
+
+	_, err := c.SendRequest("GET", server.URL, nil, nil) //nolint:bodyclose
+	assert.Error(t, err)
+
+	// Should use default max retries (3), so 4 requests total
+	assert.Equal(t, int32(4), atomic.LoadInt32(&requestCount))
+}
+
+func TestClient_AutoRetryExponentialBackoff(t *testing.T) {
+	// Create a server that always returns 429
+	requestCount := int32(0)
+	requestTimes := make([]time.Time, 0)
+	server := httptest.NewServer(http.HandlerFunc(
+		func(writer http.ResponseWriter, request *http.Request) {
+			atomic.AddInt32(&requestCount, 1)
+			requestTimes = append(requestTimes, time.Now())
+			writer.WriteHeader(http.StatusTooManyRequests)
+			_, _ = writer.Write([]byte(`{"status": 429, "code": 20429, "message": "Too Many Requests", "more_info": "https://www.twilio.com/docs/errors/20429"}`))
+		}))
+	defer server.Close()
+
+	c := NewClient("user", "pass")
+	c.SetAutoRetry(true)
+	c.SetMaxRetries(2)
+	c.SetMaxRetryDelay(1000) // 1 second max
+
+	_, err := c.SendRequest("GET", server.URL, nil, nil) //nolint:bodyclose
+	assert.Error(t, err)
+
+	// Should make 3 requests total (initial + 2 retries)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&requestCount))
+
+	// Verify that delays increase (allowing for jitter, just check they happened)
+	assert.Greater(t, len(requestTimes), 1)
+	// First retry should have some delay
+	firstDelay := requestTimes[1].Sub(requestTimes[0])
+	assert.Greater(t, firstDelay, time.Duration(0))
+	// Delays should be present (not testing exact exponential due to jitter)
+	secondDelay := requestTimes[2].Sub(requestTimes[1])
+	assert.Greater(t, secondDelay, time.Duration(0))
+}
+
+func TestClient_AutoRetrySuccessDoesNotRetry(t *testing.T) {
+	// Create a server that always succeeds
+	requestCount := int32(0)
+	server := httptest.NewServer(http.HandlerFunc(
+		func(writer http.ResponseWriter, request *http.Request) {
+			atomic.AddInt32(&requestCount, 1)
+			writer.WriteHeader(http.StatusOK)
+			d := map[string]interface{}{"response": "ok"}
+			_ = json.NewEncoder(writer).Encode(&d)
+		}))
+	defer server.Close()
+
+	c := NewClient("user", "pass")
+	c.SetAutoRetry(true)
+	c.SetMaxRetries(3)
+
+	resp, err := c.SendRequest("GET", server.URL, nil, nil) //nolint:bodyclose
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Should only make one request (success on first try)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&requestCount))
+}

--- a/twilio.go
+++ b/twilio.go
@@ -307,3 +307,20 @@ func (c *RestClient) SetEdge(edge string) {
 func (c *RestClient) SetRegion(region string) {
 	c.RequestHandler.Region = region
 }
+
+// SetAutoRetry enables or disables automatic retry with exponential backoff on 429 responses.
+func (c *RestClient) SetAutoRetry(autoRetry bool) {
+	c.RequestHandler.Client.SetAutoRetry(autoRetry)
+}
+
+// SetMaxRetryDelay sets the maximum retry delay in milliseconds for 429 responses.
+// Defaults to 3000ms if not set.
+func (c *RestClient) SetMaxRetryDelay(maxRetryDelay int) {
+	c.RequestHandler.Client.SetMaxRetryDelay(maxRetryDelay)
+}
+
+// SetMaxRetries sets the maximum number of request retries for 429 responses.
+// Defaults to 3 if not set.
+func (c *RestClient) SetMaxRetries(maxRetries int) {
+	c.RequestHandler.Client.SetMaxRetries(maxRetries)
+}

--- a/twilio_retry_test.go
+++ b/twilio_retry_test.go
@@ -1,0 +1,99 @@
+package twilio_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/twilio/twilio-go"
+	"github.com/twilio/twilio-go/client"
+)
+
+func TestRestClient_SetAutoRetryConfiguration(t *testing.T) {
+	// Create a server that returns 429 twice, then succeeds
+	requestCount := int32(0)
+	server := httptest.NewServer(http.HandlerFunc(
+		func(writer http.ResponseWriter, request *http.Request) {
+			count := atomic.AddInt32(&requestCount, 1)
+			if count <= 2 {
+				writer.WriteHeader(http.StatusTooManyRequests)
+				_, _ = writer.Write([]byte(`{"status": 429, "code": 20429, "message": "Too Many Requests", "more_info": "https://www.twilio.com/docs/errors/20429"}`))
+			} else {
+				writer.WriteHeader(http.StatusOK)
+				d := map[string]interface{}{"response": "ok"}
+				_ = json.NewEncoder(writer).Encode(&d)
+			}
+		}))
+	defer server.Close()
+
+	// Create a custom client with retry configuration
+	baseClient := &client.Client{
+		Credentials: client.NewCredentials("test", "test"),
+	}
+	baseClient.SetAccountSid("ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+
+	restClient := twilio.NewRestClientWithParams(twilio.ClientParams{
+		Client: baseClient,
+	})
+
+	// Configure retry behavior
+	restClient.SetAutoRetry(true)
+	restClient.SetMaxRetries(3)
+	restClient.SetMaxRetryDelay(100) // Short delay for testing
+
+	// Make a request
+	resp, err := restClient.RequestHandler.Get(server.URL, nil, nil, "")
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Should have made 3 requests (2 failures + 1 success)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&requestCount))
+}
+
+func TestRestClient_AutoRetryDisabledByDefault(t *testing.T) {
+	// Create a server that always returns 429
+	requestCount := int32(0)
+	server := httptest.NewServer(http.HandlerFunc(
+		func(writer http.ResponseWriter, request *http.Request) {
+			atomic.AddInt32(&requestCount, 1)
+			writer.WriteHeader(http.StatusTooManyRequests)
+			_, _ = writer.Write([]byte(`{"status": 429, "code": 20429, "message": "Too Many Requests", "more_info": "https://www.twilio.com/docs/errors/20429"}`))
+		}))
+	defer server.Close()
+
+	restClient := twilio.NewRestClient()
+	// Don't enable auto-retry
+
+	_, err := restClient.RequestHandler.Get(server.URL, nil, nil, "")
+	assert.Error(t, err)
+
+	// Should only make one request
+	assert.Equal(t, int32(1), atomic.LoadInt32(&requestCount))
+}
+
+func TestRestClient_SetAutoRetryCustomRetries(t *testing.T) {
+	// Create a server that always returns 429
+	requestCount := int32(0)
+	server := httptest.NewServer(http.HandlerFunc(
+		func(writer http.ResponseWriter, request *http.Request) {
+			atomic.AddInt32(&requestCount, 1)
+			writer.WriteHeader(http.StatusTooManyRequests)
+			_, _ = writer.Write([]byte(`{"status": 429, "code": 20429, "message": "Too Many Requests", "more_info": "https://www.twilio.com/docs/errors/20429"}`))
+		}))
+	defer server.Close()
+
+	restClient := twilio.NewRestClient()
+	restClient.SetAutoRetry(true)
+	restClient.SetMaxRetries(5) // Custom retry count
+	restClient.SetMaxRetryDelay(50)
+
+	_, err := restClient.RequestHandler.Get(server.URL, nil, nil, "")
+	assert.Error(t, err)
+
+	// Should make 6 requests total (initial + 5 retries)
+	assert.Equal(t, int32(6), atomic.LoadInt32(&requestCount))
+}


### PR DESCRIPTION
Fixes #247

Adds a mechanism very similar to `twilio-node` for handling 429 responses from the API with an auto-retry with exponential backoff. The default behavior is unchanged; auto-retry must be opted-in using `client.SetAutoRetry(true)`.

When enabled, the functionality can be adjusted per the needs of the user:
- **`SetMaxRetries(int)`**: Set the maximum number of retry attempts (default: `3`)
- **`SetMaxRetryDelay(int)`**: Set the maximum retry delay in milliseconds (default: `3000`)

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-go/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified
