### PR TITLE
feat: allow host override on RequestHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,23 @@ This will result in the `hostname` transforming from `api.twilio.com` to `api.sy
 
 A Twilio client constructed without these parameters will also look for `TWILIO_REGION` and `TWILIO_EDGE` variables inside the current environment.
 
+### Override the request host
+
+```go
+package main
+
+import (
+	"github.com/twilio/twilio-go"
+)
+
+func main() {
+	client := twilio.NewRestClient()
+	client.SetHost("localhost:4010")
+}
+```
+
+`SetHost` replaces the request host for every product (`api.twilio.com`, `lookups.twilio.com`, ...). When set, Edge/Region splicing is skipped. Intended for [Prism](https://stoplight.io/open-source/prism) mocks, recorded-cassette tests, and self-hosted proxies. The `TWILIO_HOST` environment variable is honored when the client is constructed without an explicit override.
+
 ### Buy a phone number
 
 ```go

--- a/client/request_handler.go
+++ b/client/request_handler.go
@@ -12,6 +12,7 @@ type RequestHandler struct {
 	Client BaseClient
 	Edge   string
 	Region string
+	Host   string
 }
 
 func NewRequestHandler(client BaseClient) *RequestHandler {
@@ -19,6 +20,7 @@ func NewRequestHandler(client BaseClient) *RequestHandler {
 		Client: client,
 		Edge:   os.Getenv("TWILIO_EDGE"),
 		Region: os.Getenv("TWILIO_REGION"),
+		Host:   os.Getenv("TWILIO_HOST"),
 	}
 }
 
@@ -40,6 +42,11 @@ func (c *RequestHandler) BuildUrl(rawURL string) (string, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return "", err
+	}
+
+	if c.Host != "" {
+		u.Host = c.Host
+		return u.String(), nil
 	}
 
 	var (

--- a/client/request_handler_test.go
+++ b/client/request_handler_test.go
@@ -52,6 +52,19 @@ func TestRequestHandler_BuildHostRawHostWithoutPeriods(t *testing.T) {
 	assert.Equal(t, "https://prism_twilio:4010", assertAndGetURL(t, requestHandler, "https://prism_twilio:4010"))
 }
 
+func TestRequestHandler_BuildUrlSetHost(t *testing.T) {
+	requestHandler := NewRequestHandler("user", "pass")
+	requestHandler.Host = "localhost:4010"
+	assert.Equal(t, "https://localhost:4010/2010-04-01/Accounts/AC.json",
+		assertAndGetURL(t, requestHandler, "https://api.twilio.com/2010-04-01/Accounts/AC.json"))
+
+	// Host wins over Edge/Region.
+	requestHandler.Edge = "edge"
+	requestHandler.Region = "region"
+	assert.Equal(t, "https://localhost:4010/v2/PhoneNumbers/+15551230000",
+		assertAndGetURL(t, requestHandler, "https://lookups.twilio.com/v2/PhoneNumbers/+15551230000"))
+}
+
 func TestRequestHandler_BuildUrlInvalidCTLCharacter(t *testing.T) {
 	requestHandler := NewRequestHandler("user", "pass")
 	rawURL := "https://api.twilio.com/ServiceId\n"

--- a/twilio.go
+++ b/twilio.go
@@ -307,3 +307,9 @@ func (c *RestClient) SetEdge(edge string) {
 func (c *RestClient) SetRegion(region string) {
 	c.RequestHandler.Region = region
 }
+
+// SetHost overrides the request host (e.g. "localhost:4010"). When set, Edge
+// and Region splicing is skipped. Intended for mocks and self-hosted proxies.
+func (c *RestClient) SetHost(host string) {
+	c.RequestHandler.Host = host
+}


### PR DESCRIPTION
  # Fixes

  _No issue — feature request._

  Adds `RestClient.SetHost(host)` and a `Host` field on `RequestHandler` that
  override the request host (e.g. `api.twilio.com` → `localhost:4010`) for
  pointing the SDK at a local mock. When `Host` is set, Edge/Region splicing is
  skipped. `TWILIO_HOST` is honored as an environment variable, mirroring the
  existing `TWILIO_EDGE` / `TWILIO_REGION` pattern.

  `Host` defaults to empty; existing behavior is unchanged.

  ### Checklist
  - [x] I acknowledge that all my contributions will be made under the project's license
  - [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
  - [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-go/blob/main/CONTRIBUTING.md) and my PR follows them
  - [x] I have titled the PR appropriately
  - [x] I have updated my branch with the main branch
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] I have added the necessary documentation about the functionality in the appropriate .md file
  - [x] I have added inline documentation to the code I modified

